### PR TITLE
Ne pas modifier / supprimer les types d'absence natifs : partie 1

### DIFF
--- a/App/Libraries/ApiClient.php
+++ b/App/Libraries/ApiClient.php
@@ -114,7 +114,7 @@ final class ApiClient
      * @param array $options Options de requête
      * @example ['headers' => [], 'body' => []]
      *
-     * @return \stdClass Au format Jsend
+     * @return array Au format Jsend
      * @throws \LogicException Si la requête est mal formée (Http4XX)
      */
     private function request($method, $uri, array $options)
@@ -136,12 +136,12 @@ final class ApiClient
 
         $body = $response->getBody();
         if (empty((string) $body)) {
-            $emptyClass = new \stdClass();
-            $emptyClass->code = $response->getStatusCode();
-            $emptyClass->message = $response->getReasonPhrase();
-            $emptyClass->status = 'success';
-            $emptyClass->data = [];
-            return $emptyClass;
+            return [
+                'code' => $response->getStatusCode(),
+                'message' => $response->getReasonPhrase(),
+                'status' => 'success',
+                'data' => [],
+            ];
         }
         $jsonBody = json_decode($body, true);
         if (null === $jsonBody) {

--- a/App/Patchs/Maj/1.12.1.sql
+++ b/App/Patchs/Maj/1.12.1.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `conges_type_absence`
+    ADD `type_natif` TINYINT(1) NOT NULL DEFAULT 0
+;
+
+UPDATE `conges_type_absence` SET type_natif = 1 WHERE ta_short_libelle IN ('cp', 'rtt', 'fo', 'mi', 'ab', 'mal');

--- a/App/Views/Configuration/Type_Absence/Liste.php
+++ b/App/Views/Configuration/Type_Absence/Liste.php
@@ -25,12 +25,14 @@
                 <td><strong><?= $conge['libelle'] ?></strong></td>
                 <td><?= $conge['libelleCourt'] ?></td>
                 <td class="action">
-                    <a href="<?= $PHP_SELF ?>?action=modif&id_to_update=<?= $conge['id'] ?>" title=" <?= _('form_modif') ?>"><i class="fa fa-pencil"></i></a>
-                    &nbsp;
                     <?php if (!$conge['typeNatif']) : ?>
+                        <a href="<?= $PHP_SELF ?>?action=modif&id_to_update=<?= $conge['id'] ?>" title=" <?= _('form_modif') ?>"><i class="fa fa-pencil"></i></a>
+                        &nbsp;
                         <a href="<?= $PHP_SELF ?>?action=suppr&id_to_update=<?= $conge['id'] ?>" title=" <?= _('form_supprim') ?>"><i class="fa fa-times-circle"></i></a>
                     <?php else : ?>
-                        <i class="fa fa-times-circle disabled"></i></a>
+                        <i class="fa fa-pencil disabled" title="Type d'absence natif"></i>
+                        &nbsp;
+                        <i class="fa fa-times-circle disabled" title="Type d'absence natif"></i></a>
                     <?php endif; ?>
                 </td>
             </tr>

--- a/App/Views/Configuration/Type_Absence/Liste.php
+++ b/App/Views/Configuration/Type_Absence/Liste.php
@@ -22,12 +22,12 @@
     <?php else : ?>
         <?php foreach ($conges as $conge) : ?>
             <tr>
-                <td><strong><?= $conge['ta_libelle'] ?></strong></td>
-                <td><?= $conge['ta_short_libelle'] ?></td>
+                <td><strong><?= $conge['libelle'] ?></strong></td>
+                <td><?= $conge['libelleCourt'] ?></td>
                 <td class="action">
-                    <a href="<?= $PHP_SELF ?>?action=modif&id_to_update=<?= $conge['ta_id'] ?>" title=" <?= _('form_modif') ?>"><i class="fa fa-pencil"></i></a>
+                    <a href="<?= $PHP_SELF ?>?action=modif&id_to_update=<?= $conge['id'] ?>" title=" <?= _('form_modif') ?>"><i class="fa fa-pencil"></i></a>
                     &nbsp;
-                    <a href="<?= $PHP_SELF ?>?action=suppr&id_to_update=<?= $conge['ta_id'] ?>" title=" <?= _('form_supprim') ?>"><i class="fa fa-times-circle"></i></a>
+                    <a href="<?= $PHP_SELF ?>?action=suppr&id_to_update=<?= $conge['id'] ?>" title=" <?= _('form_supprim') ?>"><i class="fa fa-times-circle disabled"></i></a>
                 </td>
             </tr>
         <?php endforeach ; ?>
@@ -49,7 +49,7 @@
             <td><input class="form-control" type="text" name="tab_new_values[short_libelle]" size="3" maxlength="3" value="<?= $nouveauLibelleCourt ?>"></td>
             <td>
                 <select class="form-control" name=tab_new_values[type]>
-                <?php foreach ($enumTypeConges as $typeConge) : ?>
+                <?php foreach (array_keys($listeTypeConges) as $typeConge) : ?>
                     <option <?= ($typeConge == $nouveauType) ? 'selected' : '' ?>><?= $typeConge ?></option>
                 <?php endforeach ;?>
                 </select>

--- a/App/Views/Configuration/Type_Absence/Liste.php
+++ b/App/Views/Configuration/Type_Absence/Liste.php
@@ -27,7 +27,11 @@
                 <td class="action">
                     <a href="<?= $PHP_SELF ?>?action=modif&id_to_update=<?= $conge['id'] ?>" title=" <?= _('form_modif') ?>"><i class="fa fa-pencil"></i></a>
                     &nbsp;
-                    <a href="<?= $PHP_SELF ?>?action=suppr&id_to_update=<?= $conge['id'] ?>" title=" <?= _('form_supprim') ?>"><i class="fa fa-times-circle disabled"></i></a>
+                    <?php if (!$conge['typeNatif']) : ?>
+                        <a href="<?= $PHP_SELF ?>?action=suppr&id_to_update=<?= $conge['id'] ?>" title=" <?= _('form_supprim') ?>"><i class="fa fa-times-circle"></i></a>
+                    <?php else : ?>
+                        <i class="fa fa-times-circle disabled"></i></a>
+                    <?php endif; ?>
                 </td>
             </tr>
         <?php endforeach ; ?>

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -465,12 +465,27 @@ class Fonctions
         //requête qui récupère les informations de la table conges_periode
         $sql1 = 'SELECT p_num FROM conges_periode WHERE p_type="'. \includes\SQL::quote($id_to_update).'"';
         $ReqLog1 = \includes\SQL::query($sql1);
+        $withErreur = false;
 
-        $count= ($ReqLog1->num_rows) ;
+        if (0 !== $ReqLog1->num_rows) {
+            $raison = _('config_abs_already_used');
+            $withErreur = true;
+        }
 
-        if( $count!=0 ) {
+        $sql = \includes\SQL::singleton();
+        $config = new \App\Libraries\Configuration($sql);
+        $injectableCreator = new \App\Libraries\InjectableCreator($sql, $config);
+        $api = $injectableCreator->get(\App\Libraries\ApiClient::class);
+        $absenceType = $api->get('absence/type/' . $id_to_update, $_SESSION['token'])['data'];
+
+        if ($absenceType['typeNatif']) {
+            $raison = _('config_abs_type_natif');
+            $withErreur = true;
+        }
+
+        if($withErreur) {
             $return .= '<center>';
-            $return .= '<br>' . _('config_abs_suppr_impossible') . '<br>' . _('config_abs_already_used') . '<br>';
+            $return .= '<br>' . _('config_abs_suppr_impossible') . '<br>' . $raison . '<br>';
 
             $return .= '<br>';
             $return .= '<form action="' . $URL . '" method="POST">';

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -538,6 +538,17 @@ class Fonctions
             $erreur=TRUE;
         }
 
+        $sql = \includes\SQL::singleton();
+        $config = new \App\Libraries\Configuration($sql);
+        $injectableCreator = new \App\Libraries\InjectableCreator($sql, $config);
+        $api = $injectableCreator->get(\App\Libraries\ApiClient::class);
+        $absenceType = $api->get('absence/type/' . $id_to_update, $_SESSION['token'])['data'];
+
+        if ($absenceType['typeNatif']) {
+            $return .= '<br>' . _('config_abs_saisie_not_ok') . ' : ' . _('config_abs_type_natif') . '<br>';
+            $erreur = true;
+        }
+
         if($erreur) {
             $return .= '<br>';
             $return .= '<form action="' . $PHP_SELF . '" method="POST">';

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -543,10 +543,25 @@ class Fonctions
         $config = new \App\Libraries\Configuration($sql);
         $injectableCreator = new \App\Libraries\InjectableCreator($sql, $config);
         $api = $injectableCreator->get(\App\Libraries\ApiClient::class);
-        $absenceType = $api->get('absence/type/' . $id_to_update, $_SESSION['token'])['data'];
+        $absenceTypes = $api->get('absence/type/', $_SESSION['token'])['data'];
+
+        $absence = [];
+        $absenceWithLibelle = [];
+        foreach ($absenceTypes as $at) {
+            if ($at['id'] === $id_to_update) {
+                $absence = $at;
+            }
+            if ($tab_new_values['short_libelle'] === $at['libelleCourt'] && $at['id'] !== $id_to_update) {
+                $absenceWithLibelle[] = $at;
+            }
+        }
+        if (!empty($absenceWithLibelle)) {
+            $return .= '<br>' . _('config_abs_saisie_not_ok') . ' : ' . _('libelle_court_existant') . '<br>';
+            $erreur = true;
+        }
 
         // @TODO 2018-09-08 : avance de phase pour l'API. À enlever quand l'API sera consommée
-        if (isset($absenceType['typeNatif']) && $absenceType['typeNatif']) {
+        if (isset($absence['typeNatif']) && $absence['typeNatif']) {
             $return .= '<br>' . _('config_abs_saisie_not_ok') . ' : ' . _('config_abs_type_natif') . '<br>';
             $erreur = true;
         }

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -478,7 +478,8 @@ class Fonctions
         $api = $injectableCreator->get(\App\Libraries\ApiClient::class);
         $absenceType = $api->get('absence/type/' . $id_to_update, $_SESSION['token'])['data'];
 
-        if ($absenceType['typeNatif']) {
+        // @TODO 2018-09-08 : avance de phase pour l'API. À enlever quand l'API sera consommée
+        if (isset($absenceType['typeNatif']) && $absenceType['typeNatif']) {
             $raison = _('config_abs_type_natif');
             $withErreur = true;
         }
@@ -544,7 +545,8 @@ class Fonctions
         $api = $injectableCreator->get(\App\Libraries\ApiClient::class);
         $absenceType = $api->get('absence/type/' . $id_to_update, $_SESSION['token'])['data'];
 
-        if ($absenceType['typeNatif']) {
+        // @TODO 2018-09-08 : avance de phase pour l'API. À enlever quand l'API sera consommée
+        if (isset($absenceType['typeNatif']) && $absenceType['typeNatif']) {
             $return .= '<br>' . _('config_abs_saisie_not_ok') . ' : ' . _('config_abs_type_natif') . '<br>';
             $erreur = true;
         }

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -371,8 +371,19 @@ class Fonctions
             $erreur=TRUE;
         }
 
-        // TODO : vérif unicité données
-
+        // vérif unicité du libellé court
+        $sql = \includes\SQL::singleton();
+        $config = new \App\Libraries\Configuration($sql);
+        $injectableCreator = new \App\Libraries\InjectableCreator($sql, $config);
+        $api = $injectableCreator->get(\App\Libraries\ApiClient::class);
+        $absenceTypes = $api->get('absence/type', $_SESSION['token'])['data'];
+        $absenceWithLibelle = array_filter($absenceTypes, function (array $type) use ($tab_new_values) {
+            return $tab_new_values['short_libelle'] === $type['libelleCourt'];
+        });
+        if (!empty($absenceWithLibelle)) {
+            $return .= '<br>' . _('config_abs_saisie_not_ok') . ' : ' . _('libelle_court_existant') . '<br>';
+            $erreur = true;
+        }
 
         if($erreur) {
             $return .= '<br>';

--- a/config/config_type_absence.php
+++ b/config/config_type_absence.php
@@ -51,6 +51,10 @@ switch ($action) {
         $api = $injectableCreator->get(\App\Libraries\ApiClient::class);
         $absenceTypes = $api->get('absence/type', $_SESSION['token'])['data'];
         foreach ($absenceTypes as $type) {
+            // @TODO 2018-09-08 : avance de phase pour l'API. À enlever quand l'API sera consommée
+            if (!isset($type['typeNatif'])) {
+                $type += ['typeNatif' => false];
+            }
             $listeTypeConges[$type['type']][] = $type;
         }
         if (!$config->isCongesExceptionnelsActive() && isset($listeTypeConges['conges_exceptionnels'])) {

--- a/includes/fonctions_conges.php
+++ b/includes/fonctions_conges.php
@@ -1526,7 +1526,7 @@ function recup_infos_all_users_du_grand_resp($login)
     return $tab ;
 }
 
-// execute sequentiellement les requètes d'un fichier .sql
+// execute sequentiellement les requêtes d'un fichier .sql
 function execute_sql_file($file) : bool
 {
     // lecture du fichier SQL


### PR DESCRIPTION
Cf. #232 

Première partie du ticket dédié à la restriction des mouvements autour des types d'absence de base. La solution technique trouvée a été de créer une valeur en DB permettre de discriminer les types ajoutés par nos soins et ceux créés par l'utilisateur, dans le but qu'à terme cette valeur nous serve à restreindre les opérations sensibles. Pour l'heure, et puisque #688 est aussi dans les cartons, seule la création de cette valeur par le patcher et le formulaire de création sont en place. Il n'y a pas encore de lecture de cette info, attendu que l'API ne la retourne pas. La partie 2 du ticket et le retour de cette valeur par l'API ; la partie 3 étant le traitement de l'info venant de l'API.

Par contre, j'ai malgré tout mis un contrôle serveur (car c'est toujours mieux) sur la suppression des types natifs (pour la modification, c'est en cours).
J'en ai profité pour mettre un contrôle sur la duplication du `short_libelle` ; j'en aurais eu besoin pour le patch et c'est toujours mieux.