### PR TITLE
Retrait des options lié a feu admin

### DIFF
--- a/App/Libraries/Configuration.php
+++ b/App/Libraries/Configuration.php
@@ -214,28 +214,6 @@ class Configuration {
     }
 
     /**
-     * Permet aux admin d'accéder à la configuration globale
-     * 
-     * @return boolean
-     */
-    public function canAdminAccessConfig() {
-        return $this->getGroupeAdministrateurValeur('affiche_bouton_config_pour_admin');
-    }
-
-    /**
-     * Permet aux admin d'accéder à la configuration des types de congés
-     * 
-     * @return boolean
-     */
-    public function canAdminConfigTypesConges() {
-        return $this->getGroupeAdministrateurValeur('affiche_bouton_config_absence_pour_admin');
-    }
-
-    public function canAdminConfigMail() {
-        return $this->getGroupeAdministrateurValeur('affiche_bouton_config_mail_pour_admin');
-    }
-
-    /**
      * Retourne une valeur du groupe administrateur par son nom
      *
      * @param string $nom

--- a/App/Patchs/Maj/1.12.0.sql
+++ b/App/Patchs/Maj/1.12.0.sql
@@ -1,1 +1,5 @@
 INSERT IGNORE INTO `conges_appli` VALUES ("version_last_maj", "");
+
+DELETE FROM conges_config WHERE conf_nom = 'affiche_bouton_config_pour_admin';
+DELETE FROM conges_config WHERE conf_nom = 'affiche_bouton_config_absence_pour_admin';
+DELETE FROM conges_config WHERE conf_nom = 'affiche_bouton_config_mail_pour_admin';

--- a/App/ProtoControllers/HautResponsable/Utilisateur.php
+++ b/App/ProtoControllers/HautResponsable/Utilisateur.php
@@ -507,7 +507,7 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
     private static function isFormInsertValide($data, &$errors, \includes\SQL $sql, \App\Libraries\Configuration $config)
     {
         $return = true;
-        $users = \App\ProtoControllers\Utilisateur::getListId(false, true);
+        $users = \App\ProtoControllers\Utilisateur::getListId(false);
         if (in_array($data['login'], $users)) {
             $errors[] = _('Cet identifiant existe déja.');
             $return = false;
@@ -535,7 +535,7 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
     private static function isFormUpdateValide($data, &$errors, \includes\SQL $sql, \App\Libraries\Configuration $config)
     {
         $return = true;
-        $users = \App\ProtoControllers\Utilisateur::getListId(false, true);
+        $users = \App\ProtoControllers\Utilisateur::getListId(false);
         if (in_array($data['login'], $users) && $data['login'] != $data['oldLogin']) {
             $errors[] = _('Cet identifiant existe déja.');
             $return = false;
@@ -700,7 +700,7 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
                     OR conges_groupe_grd_resp.ggr_login = "' . $user . '"
                 )';
         $query = $sql->query($req);
-        return 0 >= (int) $query->fetch_array()[0] && $user != 'admin';
+        return 0 >= (int) $query->fetch_array()[0];
     }
 
     /**

--- a/App/ProtoControllers/Utilisateur.php
+++ b/App/ProtoControllers/Utilisateur.php
@@ -14,14 +14,11 @@ class Utilisateur
      * SQL
      */
 
-    public static function getListId($activeSeul = false, $withAdmin = false)
+    public static function getListId($activeSeul = false)
     {
         $sql = \includes\SQL::singleton();
         $req = 'SELECT u_login
                 FROM conges_users';
-        if (!$withAdmin){
-            $req .= ' WHERE u_login != "admin"';
-        }
         if ($activeSeul){
             $req .= ' AND u_is_active = "Y"';
         }
@@ -193,7 +190,6 @@ class Utilisateur
         $req = 'SELECT *
                 FROM conges_users
                 WHERE planning_id = ' . $planningId . '
-                    AND u_login <> "admin"
                 ORDER BY u_login';
 
         return $sql->query($req)->fetch_all(\MYSQLI_ASSOC);

--- a/Public/template/menu_header.php
+++ b/Public/template/menu_header.php
@@ -9,9 +9,6 @@
     } else {
         $home = 'utilisateur/user_index.php';
     }
-    if('admin' === $_SESSION['userlogin']){
-        $home = 'admin/admin_index.php';
-    }
 
     //user mode
     $user_mode = '';

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -395,7 +395,7 @@ class Fonctions
                 // ajout dans la table conges_solde_user (pour chaque user !!)(si c'est un conges, pas si c'est une absence)
                 if ( ($tab_new_values['type']=="conges") || ($tab_new_values['type']=="conges_exceptionnels") ) {
                     // recup de users :
-                    $sql_users="SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='conges' AND u_login!='admin' " ;
+                    $sql_users="SELECT DISTINCT(u_login) FROM conges_users;" ;
 
                     $ReqLog_users = \includes\SQL::query($sql_users);
 

--- a/config/index.php
+++ b/config/index.php
@@ -23,18 +23,8 @@ $_SESSION['from_config']=true;  // initialise ce flag pour changer le bouton de 
 
 	$onglet = htmlentities(getpost_variable('onglet'), ENT_QUOTES | ENT_HTML401);
 
-	if (!$onglet && is_admin($_SESSION['userlogin']))
-	{
+	if (!$onglet && is_admin($_SESSION['userlogin'])) {
 		$onglet = 'general';
-	} elseif (!$onglet) {
-
-		if ($config->canAdminAccessConfig())
-			$onglet = 'general';
-		elseif ($config->canAdminConfigTypesConges())
-			$onglet = 'type_absence';
-		elseif ($config->canAdminConfigMail())
-			$onglet = 'config_mail';
-
 	}
 
 	/*********************************/
@@ -43,16 +33,12 @@ $_SESSION['from_config']=true;  // initialise ce flag pour changer le bouton de 
 
 	$onglets = [];
 
-	if ($config->canAdminAccessConfig() || is_admin($_SESSION['userlogin']))
-		$onglets['general'] = _('install_config_appli');
-
-	if ($config->canAdminConfigTypesConges() || is_admin($_SESSION['userlogin']))
-		$onglets['type_absence'] = _('install_config_types_abs');
-
-	if ($config->canAdminConfigMail() || is_admin($_SESSION['userlogin']))
-		$onglets['mail'] = _('install_config_mail');
-
-	$onglets['logs'] = _('config_logs');
+	if (is_admin($_SESSION['userlogin'])) {
+            $onglets['general'] = _('install_config_appli');
+            $onglets['type_absence'] = _('install_config_types_abs');
+            $onglets['mail'] = _('install_config_mail');
+            $onglets['logs'] = _('config_logs');
+        }
 
 	/*********************************/
 	/*   COMPOSITION DU HEADER...    */

--- a/config/index.php
+++ b/config/index.php
@@ -26,7 +26,7 @@ $_SESSION['from_config']=true;  // initialise ce flag pour changer le bouton de 
 	if (!$onglet && is_admin($_SESSION['userlogin']))
 	{
 		$onglet = 'general';
-	} elseif (!$onglet && $_SESSION['userlogin']!="admin") {
+	} elseif (!$onglet) {
 
 		if ($config->canAdminAccessConfig())
 			$onglet = 'general';

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -1362,7 +1362,7 @@ class Fonctions
         $tab=array();
         $list_groupes_double_validation=get_list_groupes_double_valid();
 
-        $sql1 = "SELECT u_login FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_nom";
+        $sql1 = "SELECT u_login FROM conges_users ORDER BY u_nom";
         $ReqLog = \includes\SQL::singleton()->query($sql1) ;
 
         while ($resultat = $ReqLog->fetch_array()) {
@@ -1379,7 +1379,7 @@ class Fonctions
     {
         $list_users="";
 
-        $sql1="SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='conges' AND u_login!='admin' AND u_is_active='Y' ORDER BY u_nom  ";
+        $sql1="SELECT DISTINCT(u_login) FROM conges_users WHERE u_is_active='Y' ORDER BY u_nom  ";
         $ReqLog1 = \includes\SQL::singleton()->query($sql1);
 
         while ($resultat1 = $ReqLog1->fetch_array())
@@ -1561,7 +1561,7 @@ class Fonctions
         $db = \includes\SQL::singleton();
         // verif
         $appli_num_exercice = $_SESSION['config']['num_exercice'] ;
-        $sql_verif = "SELECT u_login FROM conges_users WHERE u_login != 'admin' AND u_login != 'conges' AND u_num_exercice != $appli_num_exercice "  ;
+        $sql_verif = "SELECT u_login FROM conges_users WHERE u_num_exercice != $appli_num_exercice "  ;
         $ReqLog_verif = $db->query($sql_verif) ;
 
         if ($ReqLog_verif->num_rows == 0) {

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -479,7 +479,7 @@ function authentification_AD_SSO()
 function storeTokenApi(\App\Libraries\ApiClient $apiClient, $username, $userPassword)
 {
     $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
-    if ('dbconges' == $config->getHowToConnectUser() || "admin" == $username) {
+    if ('dbconges' == $config->getHowToConnectUser()) {
         $dataUser = $apiClient->authentifyDbConges($username, $userPassword);
     } else {
         $dataUser = $apiClient->authentifyThirdParty($username);

--- a/includes/fonctions_conges.php
+++ b/includes/fonctions_conges.php
@@ -625,7 +625,7 @@ function get_list_all_users_du_resp($resp_login)
         $groupeIds = \App\ProtoControllers\Responsable::getIdGroupeResp($resp_login);
         $listUsers = \App\ProtoControllers\Groupe\Utilisateur::getListUtilisateurByGroupeIds($groupeIds);
         $list_users="";
-    $sql1="SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='conges' AND u_login!='admin' AND u_login!='$resp_login'";
+    $sql1="SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='$resp_login'";
         $sql1 .= ' AND u_login IN ("' . implode('","', $listUsers) . '")';
 
     $sql1 = $sql1." ORDER BY u_login " ;
@@ -644,7 +644,7 @@ function get_list_all_users_du_resp($resp_login)
     // on recup la liste des users des resp absents, dont $resp_login est responsable
     if ($config->isGestionResponsableAbsent()) {
         // recup liste des resp absents, dont $resp_login est responsable
-        $sql_2='SELECT DISTINCT(u_login) FROM conges_users WHERE u_is_resp=\'Y\' AND u_login!="'. $db->quote($resp_login).'" AND u_login!=\'conges\' AND u_login!=\'admin\'';
+        $sql_2='SELECT DISTINCT(u_login) FROM conges_users WHERE u_is_resp=\'Y\' AND u_login!="'. $db->quote($resp_login).'"';
         $sql_2=$sql_2.' AND u_login IN ("' . implode('","', $listUsers) . '")';
 
         $sql_2 = $sql_2." ORDER BY u_login " ;
@@ -821,7 +821,7 @@ function get_list_groupes_du_user($user_login)
 function get_list_all_users()
 {
     $list_users="";
-    $sql1="SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_login " ;
+    $sql1="SELECT DISTINCT(u_login) FROM conges_users ORDER BY u_login " ;
     $ReqLog1 = \includes\SQL::singleton()->query($sql1);
 
     while ($resultat1 = $ReqLog1->fetch_array())
@@ -1433,7 +1433,7 @@ function recup_infos_all_users()
 {
     $tab=array();
     $list_groupes_double_validation=get_list_groupes_double_valid();
-    $sql1 = "SELECT u_login FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_nom";
+    $sql1 = "SELECT u_login FROM conges_users ORDER BY u_nom";
     $ReqLog = \includes\SQL::singleton()->query($sql1);
 
     while ($resultat =$ReqLog->fetch_array())

--- a/index.php
+++ b/index.php
@@ -59,7 +59,7 @@ if (!session_is_valid()) {
         if (($session_username == "") || ($session_password == "")) {
             session_saisie_user_password("", "", "");
         } else {
-            if ($config->getHowToConnectUser() == "ldap" && $session_username != "admin") {
+            if ($config->getHowToConnectUser() == "ldap" ) {
                 $username_ldap = authentification_ldap_conges($session_username,$session_password);
                 if ($username_ldap != $session_username) {
                     $session_username="";
@@ -77,7 +77,7 @@ if (!session_is_valid()) {
                         errorAuthentification();
                     }
                 }
-            } elseif ($config->getHowToConnectUser() == "dbconges" || $session_username == "admin") {
+            } elseif ($config->getHowToConnectUser() == "dbconges") {
                 $username_conges = authentification_passwd_conges($session_username,$session_password);
                 try {
                     if ($username_conges != $session_username) {
@@ -109,9 +109,6 @@ if (isset($_SESSION['userlogin'])) {
         $is_hr = $row["u_is_hr"];
 		$is_resp = $row["u_is_resp"];
 		$is_active = $row["u_is_active"];
-        if('admin' === $_SESSION['userlogin']) {
-            redirect(ROOT_PATH . 'admin/db_sauve');
-        }
 		if($is_active == "N") {
 			header_error();
 			echo  _('session_compte_inactif') ."<br>\n";

--- a/responsable/Fonctions.php
+++ b/responsable/Fonctions.php
@@ -258,7 +258,7 @@ class Fonctions
         $db = \includes\SQL::singleton();
         // verif
         $appli_num_exercice = $_SESSION['config']['num_exercice'] ;
-        $sql_verif = 'SELECT u_login FROM conges_users WHERE u_login != \'admin\' AND u_login != \'conges\' AND u_num_exercice != '. $db->quote($appli_num_exercice).';';
+        $sql_verif = 'SELECT u_login FROM conges_users WHERE u_num_exercice != '. $db->quote($appli_num_exercice).';';
         $ReqLog_verif = $db->query($sql_verif);
 
         if ($ReqLog_verif->num_rows == 0) {


### PR DESCRIPTION
Suite au retrait du compte admin au profit du CLI et du HR, ce PR vient retirer les options qui n'ont plus lieu d'être. 
Pour le test rien de sorcier, il suffit de se connecter en HR et de vérifier qu'il accède bien à la configuration globale, des types de congés et des mails.