### PR TITLE
[Amélioration] saisie de l'adresse web lors de l'installation

### DIFF
--- a/App/Tools/destroy
+++ b/App/Tools/destroy
@@ -24,6 +24,12 @@ if (!\includes\SQL::existsDatabase($mysql_database)) {
     displayFail();
 }
 
+display('Vous êtes sur le point de supprimer toute la base de données!');
+$input = getValue('êtes vous sûr (y/N) :');
+if ($input != 'y' &&  $input != 'Y') {
+    displayError('Destruction annulée.');
+}
+
 display('Suppression base de données…');
 $db = \includes\SQL::singleton();
 if (!destroyDatabase($db, $mysql_database)) {

--- a/App/Tools/setup
+++ b/App/Tools/setup
@@ -51,7 +51,11 @@ display('Installation…');
 $instanceName = $argv[1] ?? null;
 display('Contrôles généraux…');
 if (null == $instanceName) {
-    displayError("Nom d'instance vide");
+    $input = getValue('Adresse web :');
+    if ($input == ''|| !filter_var($input, FILTER_VALIDATE_URL)) {
+        displayError('Saisie incorrecte! Adresse web vide ou mal formée.');
+    }
+    $instanceName = $input;
 }
 if (\includes\SQL::existsDatabase($mysql_database)) {
     displayError('Application déjà installée');


### PR DESCRIPTION
Pour installer Lt en CLI il était nécessaire de renseigner la variable `nom_instance` dans la ligne de commande. Ce PR permet de saisir le nom d'instance si cela n'a pas été fait dans la ligne de commande.
J'en ai profité pour mettre un garde-fou sur `destroy`, dans le cas contraire `make reinstall` pourrait faire de sérieux dégât.