### PR TITLE
[installation] pas d'erreur si pas d'update

### DIFF
--- a/App/Tools/update
+++ b/App/Tools/update
@@ -148,7 +148,8 @@ $versionMaj = implode('.', [$major, $minor, $patch]);
 // Le seul cas qui amènerait à ce que la version ait cette valeur ici
 // est qu'aucun script ne soit supérieur la version courante
 if ('0.0.0' === $versionMaj) {
-    displayFail();
+    display('aucune mise à jour disponible');
+    exit();
 }
 
 display('Définition du token d\'instance…');


### PR DESCRIPTION
Durant mes tests, j'ai à plusieurs reprise exécuté la commande make update (pour rien). Cel avait pour effet d'afficher une erreur qui me stressait l'espace d'une seconde... A bas le stress! Ce PR propose de mettre un gentil message pour simplement dire qu'il n'y a rien à mettre à jour 🐼 