### PR TITLE
[make] paramétrage de la configuration

### DIFF
--- a/App/Tools/configure
+++ b/App/Tools/configure
@@ -76,7 +76,7 @@ if (null == $nomOpt) {
         display(str_pad($option['conf_nom'], 40) . ' : ' . str_pad($option['conf_valeur'], 35) . ' ; ' . $option['conf_type']);
     }
 
-    displayError('exemple : make configure option="resp_ajoute_conges" valeur="TRUE"');
+    display('exemple : make configure option="resp_ajoute_conges" valeur="TRUE"');
 }
 
 if (!existOptionNom($db,$nomOpt)) {

--- a/App/Tools/configure
+++ b/App/Tools/configure
@@ -1,0 +1,65 @@
+#!/usr/bin/env php
+<?php
+require_once 'libraries';
+require_once CONFIG_PATH . 'dbconnect.php';
+
+define('INSTALLATION_PATH', PATCH_PATH . DS . 'Installation' . DS);
+define('API_PATH', ROOT_PATH . 'api' . DS);
+define('API_SYSPATH', ROOT_PATH . 'vendor' . DS . 'libertempo' . DS . 'api' . DS);
+
+function configure(\includes\SQL $db, array $data) : bool
+{
+
+    $nom = $db->escape_string(key($data));
+    $valeur = $db->escape_string(current($data));
+
+    $db->query('UPDATE conges_config 
+                SET conf_valeur = "' . $valeur . '" 
+                WHERE conf_nom = "' . $nom . '";
+    ');
+
+    return 0 < $db->affected_rows;
+}
+
+function existOptionNom(\includes\SQL $db, string $nom) : bool
+{
+    $res = $db->query('SELECT EXISTS (SELECT conf_valeur FROM conges_config WHERE conf_nom = "' . $nom . '");');
+    return 0 < (int) $res->fetch_array()[0];
+}
+
+function isOptionBoolValid(\includes\SQL $db, $data) : bool
+{
+    $req = 'SELECT * FROM conges_config WHERE conf_nom = "' . key($data) . '"';
+    $res = $db->query($req);
+    $option = $res->fetch_array()[0];
+
+    return !('boolean' == $option['conf_type'] && "TRUE" != current($data) && "FALSE" != current($data));
+}
+
+display('Configuration générale de Libertempo');
+display('Vérification de l\'accès à la base de donnée...');
+if (!\includes\SQL::existsDatabase($mysql_database)) {
+    displayFail();
+}
+
+$db = \includes\SQL::singleton();
+
+$nomOpt = $argv[1] ?? null;
+$valeurOpt = $argv[2] ?? null;
+
+if (null == $nomOpt || null == $valeurOpt) {
+    displayError('exemple : make configure option="resp_ajoute_conges" valeur="TRUE"');
+}
+
+if (!existOptionNom($db,$nomOpt)) {
+    displayError('Cette option n\'existe pas.');
+}
+
+if (!isOptionBoolValid($db,[$nomOpt => $valeurOpt])) {
+    displayError('Cette option prend uniquement pour valeur "TRUE" ou "FALSE".');
+}
+
+if (!configure($db,[$nomOpt => $valeurOpt])) {
+    displayError('Une erreur inattendue s\'est produite!');
+    displayFail();
+}

--- a/App/Tools/configure
+++ b/App/Tools/configure
@@ -3,10 +3,6 @@
 require_once 'libraries';
 require_once CONFIG_PATH . 'dbconnect.php';
 
-define('INSTALLATION_PATH', PATCH_PATH . DS . 'Installation' . DS);
-define('API_PATH', ROOT_PATH . 'api' . DS);
-define('API_SYSPATH', ROOT_PATH . 'vendor' . DS . 'libertempo' . DS . 'api' . DS);
-
 function configure(\includes\SQL $db, array $data) : bool
 {
 
@@ -24,21 +20,37 @@ function configure(\includes\SQL $db, array $data) : bool
 function existOptionNom(\includes\SQL $db, string $nom) : bool
 {
     $res = $db->query('SELECT EXISTS (SELECT conf_valeur FROM conges_config WHERE conf_nom = "' . $nom . '");');
+
     return 0 < (int) $res->fetch_array()[0];
 }
 
 function isOptionBoolValid(\includes\SQL $db, $data) : bool
 {
-    $req = 'SELECT * FROM conges_config WHERE conf_nom = "' . key($data) . '"';
-    $res = $db->query($req);
+    $res = $db->query('SELECT conf_type FROM conges_config WHERE conf_nom = "' . key($data) . '"');
     $option = $res->fetch_array()[0];
+    return !('boolean' == $option && "TRUE" != current($data) && "FALSE" != current($data));
+}
 
-    return !('boolean' == $option['conf_type'] && "TRUE" != current($data) && "FALSE" != current($data));
+function listeOptions(\includes\SQL $db) : array
+{
+    $res = $db->query('SELECT * FROM conges_config');
+    while ($option = $res->fetch_all()) {
+        $options = $option;
+    }
+    return $options;
+}
+
+function listeOptionValeur(\includes\SQL $db, $option) : string
+{
+    $res = $db->query('SELECT conf_valeur FROM conges_config WHERE conf_nom = "' . $option . '"');
+
+    return $res->fetch_array()[0];
 }
 
 display('Configuration générale de Libertempo');
-display('Vérification de l\'accès à la base de donnée...');
+
 if (!\includes\SQL::existsDatabase($mysql_database)) {
+    displayError('Accès à la base de donnée impossible!');
     displayFail();
 }
 
@@ -47,7 +59,15 @@ $db = \includes\SQL::singleton();
 $nomOpt = $argv[1] ?? null;
 $valeurOpt = $argv[2] ?? null;
 
-if (null == $nomOpt || null == $valeurOpt) {
+if (null == $nomOpt) {
+    display('commande incomplète. Veuillez définir l\'une des options suivantes :');
+    display(str_pad('OPTION', 40) . ' : ' . str_pad('VALEUR', 35) . ' ; TYPE');
+
+    $conf = listeOptions($db);
+    foreach ($conf as $option) {
+        display(str_pad($option['conf_nom'], 40) . ' : ' . str_pad($option['conf_valeur'], 35) . ' ; ' . $option['conf_type']);
+    }
+
     displayError('exemple : make configure option="resp_ajoute_conges" valeur="TRUE"');
 }
 
@@ -55,11 +75,21 @@ if (!existOptionNom($db,$nomOpt)) {
     displayError('Cette option n\'existe pas.');
 }
 
+if (null == $valeurOpt) {
+    display('Valeur de l\'option demandée : ');
+    display($nomOpt . ' : ' . listeOptionValeur($db, $nomOpt));
+    exit();
+}
+
 if (!isOptionBoolValid($db,[$nomOpt => $valeurOpt])) {
     displayError('Cette option prend uniquement pour valeur "TRUE" ou "FALSE".');
 }
 
 if (!configure($db,[$nomOpt => $valeurOpt])) {
-    displayError('Une erreur inattendue s\'est produite!');
-    displayFail();
+    display('Option ' . $nomOpt . ' non modifiée.');
+    display($nomOpt . ' : ' . listeOptionValeur($db, $nomOpt));
+    exit();
 }
+
+display('Mise à jour de l\'option ' . $nomOpt . ' effectuée.');
+display($nomOpt . ' : ' . listeOptionValeur($db, $nomOpt));

--- a/App/Tools/configure
+++ b/App/Tools/configure
@@ -95,7 +95,7 @@ if (!isOptionValid($db,[$nomOpt => $valeurOpt])) {
 
 if (!configure($db,[$nomOpt => $valeurOpt])) {
     display($nomOpt . ' : ' . listeOptionValeur($db, $nomOpt));
-    displayError('Option ' . $nomOpt . ' non modifiée.');
+    display('Option ' . $nomOpt . ' non modifiée.');
 }
 
 display('Mise à jour de l\'option ' . $nomOpt . ' effectuée.');

--- a/App/Tools/configure
+++ b/App/Tools/configure
@@ -24,11 +24,19 @@ function existOptionNom(\includes\SQL $db, string $nom) : bool
     return 0 < (int) $res->fetch_array()[0];
 }
 
-function isOptionBoolValid(\includes\SQL $db, $data) : bool
+function isOptionValid(\includes\SQL $db, $data) : bool
 {
     $res = $db->query('SELECT conf_type FROM conges_config WHERE conf_nom = "' . key($data) . '"');
     $option = $res->fetch_array()[0];
-    return !('boolean' == $option && "TRUE" != current($data) && "FALSE" != current($data));
+    switch (true) {
+        case 'boolean' == $option:
+            return ("TRUE" == current($data) || "FALSE" == current($data));
+        case 'enum' == mb_strcut($option, 0, 4):
+            $enumOpt = explode("/",mb_strcut($option, 5));
+            return in_array(current($data), $enumOpt);
+        default:
+            return true;
+    }
 }
 
 function listeOptions(\includes\SQL $db) : array
@@ -81,8 +89,8 @@ if (null == $valeurOpt) {
     exit();
 }
 
-if (!isOptionBoolValid($db,[$nomOpt => $valeurOpt])) {
-    displayError('Cette option prend uniquement pour valeur "TRUE" ou "FALSE".');
+if (!isOptionValid($db,[$nomOpt => $valeurOpt])) {
+    displayError('Saisie invalide!');
 }
 
 if (!configure($db,[$nomOpt => $valeurOpt])) {

--- a/App/Tools/configure
+++ b/App/Tools/configure
@@ -88,7 +88,6 @@ if (!isOptionBoolValid($db,[$nomOpt => $valeurOpt])) {
 if (!configure($db,[$nomOpt => $valeurOpt])) {
     display($nomOpt . ' : ' . listeOptionValeur($db, $nomOpt));
     displayError('Option ' . $nomOpt . ' non modifiée.');
-    display($nomOpt . ' : ' . listeOptionValeur($db, $nomOpt));
 }
 
 display('Mise à jour de l\'option ' . $nomOpt . ' effectuée.');

--- a/App/Tools/configure
+++ b/App/Tools/configure
@@ -19,7 +19,7 @@ function configure(\includes\SQL $db, array $data) : bool
 
 function existOptionNom(\includes\SQL $db, string $nom) : bool
 {
-    $res = $db->query('SELECT EXISTS (SELECT conf_valeur FROM conges_config WHERE conf_nom = "' . $nom . '");');
+    $res = $db->query('SELECT EXISTS (SELECT conf_valeur FROM conges_config WHERE conf_nom = "' . $db->quote($nom) . '");');
 
     return 0 < (int) $res->fetch_array()[0];
 }
@@ -50,7 +50,7 @@ function listeOptions(\includes\SQL $db) : array
 
 function listeOptionValeur(\includes\SQL $db, $option) : string
 {
-    $res = $db->query('SELECT conf_valeur FROM conges_config WHERE conf_nom = "' . $option . '"');
+    $res = $db->query('SELECT conf_valeur FROM conges_config WHERE conf_nom = "' . $db->quote($option) . '"');
 
     return $res->fetch_array()[0];
 }

--- a/App/Tools/configure
+++ b/App/Tools/configure
@@ -86,9 +86,9 @@ if (!isOptionBoolValid($db,[$nomOpt => $valeurOpt])) {
 }
 
 if (!configure($db,[$nomOpt => $valeurOpt])) {
-    display('Option ' . $nomOpt . ' non modifiée.');
     display($nomOpt . ' : ' . listeOptionValeur($db, $nomOpt));
-    exit();
+    displayError('Option ' . $nomOpt . ' non modifiée.');
+    display($nomOpt . ' : ' . listeOptionValeur($db, $nomOpt));
 }
 
 display('Mise à jour de l\'option ' . $nomOpt . ' effectuée.');

--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,6 @@ test: ## Lance les tests unitaires
 
 ## Configuration
 configure: ## Paramètre une option de configuration
-      App/Tools/configure ${option} ${valeur}
+	App/Tools/configure ${option} ${valeur}
+
 

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,8 @@ reinstall: destroy install ## Reset usine
 ## Test
 test: ## Lance les tests unitaires
 	vendor/bin/atoum -ulr
+
+## Configuration
+configure: ## Paramètre une option de configuration
+      App/Tools/configure ${option} ${valeur}
+


### PR DESCRIPTION
un PR qui a failli passer à la trappe! 😱 
make configure permet de paramétrer l'application en CLI (dans le cas ou on a perdu l'accès à l'appli web, c'est bien utile). Pour l'utiliser c'est très simple : 
make configure : affiche toutes les options et leurs valeurs
make configure option=valeur : affecte une valeur à une option.

Attention : seul les booleans sont vérifiés avant modification, il faut être vigilant lorsqu'on utilise cette commande.