### PR TITLE
[Bug] Correctly merge typeAbsence array

### DIFF
--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -82,7 +82,7 @@ class Fonctions
 
         $typeAbsence = \App\ProtoControllers\Conge::getTypesAbsences($db, 'conges');
         if ($config->isCongesExceptionnelsActive()) {
-            $typeAbsence = array_merge($typeAbsence, \App\ProtoControllers\Conge::getTypesAbsences($db, 'conges_exceptionnels'));
+            $typeAbsence += \App\ProtoControllers\Conge::getTypesAbsences($db, 'conges_exceptionnels');
         }
 
         /*********************************/


### PR DESCRIPTION
Hi,

This PR solves an issue where `$typeAbsence` array is not correctly computed.
This leads to incorrect vacation type displayed in HR requests' page.
`+` operator must be used here instead of `array_merge` which breaks IDs.

Perhaps this should also be merged to _beta_ branch in addition to the _develop_ one.

Thank you 👍 