### PR TITLE
Prise de congés avec accent

### DIFF
--- a/App/Views/Configuration/Type_Absence/Liste.php
+++ b/App/Views/Configuration/Type_Absence/Liste.php
@@ -6,6 +6,7 @@
  * $traductions
  * $url
  * $isCongesExceptionnelsActive
+ * $classesConges
  */
 ?>
 <div id="inner-content">
@@ -15,16 +16,16 @@
         aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width:100%">
         </div>
     </div>
-    <div v-for="(value, key) in absenceTypes">
-        <h2>{{ titre(key) }}</h2>
-        <p>{{ commentaire(key) }}</p>
+    <div v-for="classe in classesConges">
+        <h2>{{ titre(classe) }}</h2>
+        <p>{{ commentaire(classe) }}</p>
         <table class="table table-hover table-responsive table-condensed table-striped">
             <tr>
                 <th><?= _('config_abs_libelle') ?></th>
                 <th><?= _('config_abs_libelle_short') ?></th>
                 <th></th>
             </tr>
-            <tr v-if="!hasAbsences(key)"><td colspan="2"><center><?= _('aucun_resultat') ?></center></td></tr>
+            <tr v-if="!hasAbsences(classe)"><td colspan="2"><center><?= _('aucun_resultat') ?></center></td></tr>
             <tr v-for="absenceType in value">
                 <td><strong>{{ absenceType.libelle }}</strong></td>
                 <td>{{ absenceType.libelleCourt }}</td>
@@ -58,7 +59,7 @@
                 <td><input class="form-control" type="text" name="tab_new_values[short_libelle]" size="3" maxlength="3" :value="nouveauLibelleCourt"></td>
                 <td>
                     <select class="form-control" name=tab_new_values[type]>
-                        <option v-for="type in typesGeneraux" :selected="isSelected(type)">{{ type }}</option>
+                        <option v-for="classe in classesConges" :selected="isSelected(classe)">{{ titre(classe) }}</option>
                     </select>
                 </td>
             </tr>
@@ -91,15 +92,14 @@ var vm = new Vue({
         nouveauType : '<?= $nouveauType ?>',
         traductions : <?= json_encode($traductions) ?>,
         isCongesExceptionnelsActive: 'true' == "<?= $isCongesExceptionnelsActive ? 'true' : 'false' ?>",
-        axios : instance
+        axios : instance,
+        classesConges : <?= json_encode($classesConges) ?>
     },
     computed: {
-        typesGeneraux : function () {
-            return Object.keys(this.absenceTypes);
-        }
     },
     'methods' : {
         hasAbsences: function (type) {
+            console.log(type, this.absenceTypes);
             return 0 < this.absenceTypes[type].length;
         },
         titre: function (type) {
@@ -119,8 +119,9 @@ var vm = new Vue({
         }
     },
     created () {
-    var vm = this;
-    this.axios.get('/absence/type')
+        var vm = this;
+        console.log(document.getElementById('loader-bar'));
+        this.axios.get('/absence/type')
         .then((response) => {
             if (typeof response.data != 'object') {
                 return;
@@ -135,11 +136,13 @@ var vm = new Vue({
                 }
                 organisedTypes[absenceType.type].push(absenceType);
             }
-            if (!vm.isisCongesExceptionnelsActive && undefined != organisedTypes['conges_exceptionnels']) {
+            console.log('o', organisedTypes);
+            if (!vm.isCongesExceptionnelsActive && undefined != organisedTypes['conges_exceptionnels']) {
                 delete organisedTypes['conges_exceptionnels'];
             }
 
             // Finally hide loader and show var
+            console.log('i', organisedTypes);
             document.getElementById('loader-bar').classList.add('hidden');
             vm.absenceTypes = organisedTypes;
         })
@@ -147,7 +150,7 @@ var vm = new Vue({
             console.log(error.response);
             console.error(error);
         })
-  }
+    }
 });
 </script>
 <?php

--- a/App/Views/Configuration/Type_Absence/Liste.php
+++ b/App/Views/Configuration/Type_Absence/Liste.php
@@ -26,7 +26,7 @@
                 <th></th>
             </tr>
             <tr v-if="!hasAbsences(classe)"><td colspan="2"><center><?= _('aucun_resultat') ?></center></td></tr>
-            <tr v-for="absenceType in value">
+            <tr v-for="absenceType in absenceTypes[classe]">
                 <td><strong>{{ absenceType.libelle }}</strong></td>
                 <td>{{ absenceType.libelleCourt }}</td>
                 <td class="action">
@@ -99,8 +99,7 @@ var vm = new Vue({
     },
     'methods' : {
         hasAbsences: function (type) {
-            console.log(type, this.absenceTypes);
-            return 0 < this.absenceTypes[type].length;
+            return undefined != this.absenceTypes[type] && 0 < this.absenceTypes[type].length;
         },
         titre: function (type) {
             return this.traductions.titres[type];
@@ -120,7 +119,6 @@ var vm = new Vue({
     },
     created () {
         var vm = this;
-        console.log(document.getElementById('loader-bar'));
         this.axios.get('/absence/type')
         .then((response) => {
             if (typeof response.data != 'object') {
@@ -136,14 +134,13 @@ var vm = new Vue({
                 }
                 organisedTypes[absenceType.type].push(absenceType);
             }
-            console.log('o', organisedTypes);
             if (!vm.isCongesExceptionnelsActive && undefined != organisedTypes['conges_exceptionnels']) {
                 delete organisedTypes['conges_exceptionnels'];
             }
 
             // Finally hide loader and show var
-            console.log('i', organisedTypes);
             document.getElementById('loader-bar').classList.add('hidden');
+            console.log('o', organisedTypes);
             vm.absenceTypes = organisedTypes;
         })
         .catch((error) => {

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -324,9 +324,9 @@ class Fonctions
         $return = '';
 
         $URL = $PHP_SELF;
-        $tab_new_values['libelle'] = htmlentities($tab_new_values['libelle'], ENT_QUOTES | ENT_HTML401);
-        $tab_new_values['short_libelle'] = htmlentities($tab_new_values['short_libelle']);
-        $tab_new_values['type'] = htmlentities($tab_new_values['type'], ENT_QUOTES | ENT_HTML401);
+        $tab_new_values['libelle'] = htmlspecialchars($tab_new_values['libelle'], ENT_QUOTES | ENT_HTML401);
+        $tab_new_values['short_libelle'] = htmlspecialchars($tab_new_values['short_libelle']);
+        $tab_new_values['type'] = htmlspecialchars($tab_new_values['type'], ENT_QUOTES | ENT_HTML401);
 
         // verif de la saisie
         $erreur=FALSE ;
@@ -493,7 +493,9 @@ class Fonctions
         $return = '';
 
         $URL = $PHP_SELF;
-
+        $tab_new_values['libelle'] = htmlspecialchars($tab_new_values['libelle'], ENT_QUOTES | ENT_HTML401);
+        $tab_new_values['short_libelle'] = htmlspecialchars($tab_new_values['short_libelle']);
+        $tab_new_values['type'] = htmlspecialchars($tab_new_values['type'], ENT_QUOTES | ENT_HTML401);
 
         // verif de la saisie
         $erreur=FALSE ;

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -506,7 +506,7 @@ class Fonctions
             $erreur=TRUE;
         }
         // verif si les champs sont vides
-        if ( (strlen($tab_new_values['libelle'])==0) || (strlen($tab_new_values['short_libelle'])==0) ) {
+        if (0 === strlen($tab_new_values['libelle']) || 0 === strlen($tab_new_values['short_libelle'])) {
             $return .= '<br>' . _('config_abs_saisie_not_ok') . ' : ' . _('config_abs_champs_vides') . '<br>';
             $erreur=true;
         }
@@ -634,7 +634,7 @@ class Fonctions
 
             // CONTROLE gestion_conges_exceptionnels
             // si désactivation les conges exceptionnels, on verif s'il y a des conges exceptionnels enregistres ! si oui : changement impossible !
-            if (($key=="gestion_conges_exceptionnels") && ($value=="FALSE") ) {
+            if ('gestion_conges_exceptionnels' === $key && 'FALSE' === $value) {
                 $sql_abs="SELECT ta_id, ta_libelle FROM conges_type_absence WHERE ta_type='conges_exceptionnels' ";
                 $ReqLog_abs = \includes\SQL::query($sql_abs);
 
@@ -709,7 +709,7 @@ class Fonctions
                 $conf_type = strtolower($data['conf_type']);
                 $conf_commentaire = strtolower($data['conf_commentaire']);
 
-                if ($conf_nom=="lang") {
+                if ('lang' === $conf_nom) {
                     $childTable .= '<b>Langue installée &nbsp;&nbsp;=&nbsp;&nbsp;' . $conf_valeur . '</b><br>';
                 } else {
                     // affichage commentaire
@@ -718,22 +718,22 @@ class Fonctions
                     // affichage saisie variable
                     if ($conf_nom=="installed_version") {
                         $childTable .= '<b>' . $conf_nom . '&nbsp;&nbsp;=&nbsp;&nbsp;' . $conf_valeur . '</b><br>';
-                    } elseif ( ($conf_type=="texte") || ($conf_type=="path") ) {
+                    } elseif ('texte' === $conf_type || 'path' === $conf_type) {
                         $childTable .= '<b>' . $conf_nom . '</b>&nbsp;=&nbsp;<input type="text" class="form-control" size="50" maxlength="200" name="tab_new_values[' . $conf_nom . ']" value="' . $conf_valeur . '"><br>';
                     } elseif ($conf_type=="boolean") {
                         $childTable .= '<b>' . $conf_nom . '</b>&nbsp;=&nbsp;<select class="form-control" name="tab_new_values[' . $conf_nom . ']">';
                         $childTable .= '<option value="TRUE"';
-                        if ($conf_valeur=="TRUE") {
+                        if ('TRUE' === $conf_valeur) {
                             $childTable .= ' selected';
                         }
                         $childTable .= '>TRUE</option>';
                         $childTable .= '<option value="FALSE"';
-                        if ($conf_valeur=="FALSE") {
+                        if ('FALSE' === $conf_valeur) {
                             $childTable .= ' selected';
                         }
                         $childTable .= '>FALSE</option>';
                         $childTable .= '</select><br>';
-                    } elseif (substr($conf_type,0,4)=="enum") {
+                    } elseif (substr($conf_type,0,4) === "enum") {
                         $childTable .= '<b>' . $conf_nom . '</b>&nbsp;=&nbsp;<select class="form-control" name="tab_new_values[' . $conf_nom . ']">';
                         $options=explode("/", substr(strstr($conf_type, '='),1));
                         for ($i=0; $i<count($options); $i++) {

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -64,7 +64,7 @@ class Fonctions
             ]);
 
             $childTable = '<tr><td class="histo" colspan="5">' . _('voir_les_logs_par') . '</td>';
-            if($login_par!="") {
+            if ('' !== $login_par) {
                 $childTable .= '<tr><td class="histo" colspan="5">' . _('voir_tous_les_logs') . '<a href="/config/logs">' . _('voir_tous_les_logs') . '</a></td>';
             }
             $childTable .= '<tr><td class="histo" colspan="5">&nbsp;</td>';
@@ -137,9 +137,10 @@ class Fonctions
 
         /*************************************/
 
-        if ($action=="suppr_logs") {
+
+        if ('suppr_logs' === $action) {
             $return .= \config\Fonctions::confirmer_vider_table_logs();
-        } elseif($action=="commit_suppr_logs") {
+        } elseif ('commit_suppr_logs' === $action) {
             \config\Fonctions::commit_vider_table_logs();
         } else {
             $return .= \config\Fonctions::affichage($login_par);
@@ -157,7 +158,7 @@ class Fonctions
 
 
         // update de la table
-        foreach($tab_new_values as $nom_mail => $tab_mail) {
+        foreach ($tab_new_values as $nom_mail => $tab_mail) {
             $subject = htmlspecialchars(addslashes($tab_mail['subject']));
             $body = htmlspecialchars(addslashes($tab_mail['body']));
             $req_update='UPDATE conges_mail SET mail_subject=\''.$subject.'\', mail_body=\''.$body.'\' WHERE mail_nom="'. \includes\SQL::quote($nom_mail).'" ';
@@ -172,7 +173,7 @@ class Fonctions
         return $return;
     }
 
-    private static function test_config($tab_new_values)
+    public static function test_config()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
         $return = '';
@@ -195,7 +196,7 @@ class Fonctions
         return $return;
     }
 
-    private static function affichage_config_mail($tab_new_values)
+    public static function affichage_config_mail()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
         $return = '';
@@ -293,10 +294,10 @@ class Fonctions
         $tab_new_values = getpost_variable('tab_new_values');
         /*********************************/
 
-        if($action=="modif") {
+        if ('modif' === $action) {
             $return .= \config\Fonctions::commit_modif($tab_new_values);
         }
-        if($action=="test") {
+        if ('test' === $action) {
             $return .= \config\Fonctions::test_config($tab_new_values);
         }
 
@@ -311,7 +312,7 @@ class Fonctions
         $req_1="SELECT MAX(ta_id) FROM conges_type_absence ";
         $res_1 = \includes\SQL::query($req_1);
         $row_1 = $res_1->fetch_row();
-        if(!$row_1) {
+        if (!$row_1) {
             return 0;     // si la table est vide, on renvoit 0
         } else {
             return $row_1[0];
@@ -336,7 +337,7 @@ class Fonctions
             $erreur=TRUE;
         }
         // verif si les champs sont vides
-        if( (strlen($tab_new_values['libelle'])==0) || (strlen($tab_new_values['short_libelle'])==0) || (strlen($tab_new_values['type'])==0) ) {
+        if (0 === strlen($tab_new_values['libelle']) || 0 === strlen($tab_new_values['short_libelle']) || 0 === strlen($tab_new_values['type'])) {
             $return .= '<br>' . _('config_abs_saisie_not_ok') . ' : ' . _('config_abs_champs_vides') . '<br>';
             $erreur=TRUE;
         }
@@ -373,7 +374,7 @@ class Fonctions
             // on recup l'id de l'absence qu'on vient de créer
             $new_abs_id = \config\Fonctions::get_last_absence_id();
 
-            if($new_abs_id!=0) {
+            if (0 !== $new_abs_id) {
                 // ajout dans la table conges_solde_user (pour chaque user !!)(si c'est un conges, pas si c'est une absence)
                 if ("conges" == $tab_new_values['type'] || "conges_exceptionnels" == $tab_new_values['type']) {
                     // recup de users :
@@ -498,16 +499,16 @@ class Fonctions
         $tab_new_values['type'] = htmlspecialchars($tab_new_values['type'], ENT_QUOTES | ENT_HTML401);
 
         // verif de la saisie
-        $erreur=FALSE ;
+        $erreur=false ;
         // verif si pas de " ' , . ; % ?
-        if( (preg_match('/.*[?%;.,"\'].*$/', $tab_new_values['libelle'])) || (preg_match('/.*[?%;.,"\'].*$/', $tab_new_values['short_libelle'])) ) {
+        if ( (preg_match('/.*[?%;.,"\'].*$/', $tab_new_values['libelle'])) || (preg_match('/.*[?%;.,"\'].*$/', $tab_new_values['short_libelle'])) ) {
             $return .= '<br>' . _('config_abs_saisie_not_ok') . ' : ' . _('config_abs_bad_caracteres') . ' " \' , . ; % ? <br>';
             $erreur=TRUE;
         }
         // verif si les champs sont vides
-        if( (strlen($tab_new_values['libelle'])==0) || (strlen($tab_new_values['short_libelle'])==0) ) {
+        if ( (strlen($tab_new_values['libelle'])==0) || (strlen($tab_new_values['short_libelle'])==0) ) {
             $return .= '<br>' . _('config_abs_saisie_not_ok') . ' : ' . _('config_abs_champs_vides') . '<br>';
-            $erreur=TRUE;
+            $erreur=true;
         }
 
         $sql = \includes\SQL::singleton();
@@ -537,7 +538,7 @@ class Fonctions
             $erreur = true;
         }
 
-        if($erreur) {
+        if ($erreur) {
             $return .= '<br>';
             $return .= '<form action="' . $PHP_SELF . '" method="POST">';
             $return .= '<input type="hidden" name="action" value="modif">';
@@ -550,7 +551,7 @@ class Fonctions
         } else {
             // update de la table
             $req_update='UPDATE conges_type_absence SET ta_libelle=\''.$tab_new_values['libelle'].'\', ta_short_libelle=\''.$tab_new_values['short_libelle'].'\' WHERE ta_id="'. \includes\SQL::quote($id_to_update).'" ';
-            $result1 = \includes\SQL::query($req_update);
+            \includes\SQL::query($req_update);
 
             $return .= '<span class="messages">' . _('form_modif_ok') . '</span><br>';
 
@@ -624,7 +625,7 @@ class Fonctions
 
         $timeout=2 ;  // temps d'attente pour rafraichir l'écran après l'update !
 
-        foreach($tab_new_values as $key => $value ) {
+        foreach ($tab_new_values as $key => $value ) {
             $value = htmlentities($value, ENT_QUOTES | ENT_HTML401);
             /* Contrôle de cohérence entre config. */
             if ('user_ch_passwd' === $key && 'dbconges' !== $tab_new_values['how_to_connect_user'] ) {
@@ -633,7 +634,7 @@ class Fonctions
 
             // CONTROLE gestion_conges_exceptionnels
             // si désactivation les conges exceptionnels, on verif s'il y a des conges exceptionnels enregistres ! si oui : changement impossible !
-            if(($key=="gestion_conges_exceptionnels") && ($value=="FALSE") ) {
+            if (($key=="gestion_conges_exceptionnels") && ($value=="FALSE") ) {
                 $sql_abs="SELECT ta_id, ta_libelle FROM conges_type_absence WHERE ta_type='conges_exceptionnels' ";
                 $ReqLog_abs = \includes\SQL::query($sql_abs);
 
@@ -648,7 +649,7 @@ class Fonctions
             // si modif de jour_mois_limite_reliquats, on verifie le format ( 0 ou jj-mm) , sinon : changement impossible !
             if( ($key=="jour_mois_limite_reliquats") && ($value!= "0") ) {
                 $t=explode("-", $value);
-                if(checkdate($t[1], $t[0], date("Y"))==FALSE) {
+                if (checkdate($t[1], $t[0], date("Y"))==false) {
                     $return .= '<b>' . _('config_jour_mois_limite_reliquats_modif_impossible') . '</b><br>';
                     $sql_date="SELECT conf_valeur FROM conges_config WHERE conf_nom='jour_mois_limite_reliquats' ";
                     $ReqLog_date = \includes\SQL::query($sql_date);
@@ -689,7 +690,6 @@ class Fonctions
         $sql1 = "SELECT * FROM conges_config ORDER BY conf_groupe ASC";
         $ReqLog1 = \includes\SQL::query($sql1);
 
-        $old_groupe="";
         $config = [];
         while ($data = $ReqLog1->fetch_array()) {
             $config[$data['conf_groupe']][] = $data;
@@ -706,11 +706,10 @@ class Fonctions
             foreach ($group as $data) {
                 $conf_nom = $data['conf_nom'];
                 $conf_valeur = $data['conf_valeur'];
-                $conf_groupe = $data['conf_groupe'];
                 $conf_type = strtolower($data['conf_type']);
                 $conf_commentaire = strtolower($data['conf_commentaire']);
 
-                if($conf_nom=="lang") {
+                if ($conf_nom=="lang") {
                     $childTable .= '<b>Langue installée &nbsp;&nbsp;=&nbsp;&nbsp;' . $conf_valeur . '</b><br>';
                 } else {
                     // affichage commentaire
@@ -719,27 +718,27 @@ class Fonctions
                     // affichage saisie variable
                     if ($conf_nom=="installed_version") {
                         $childTable .= '<b>' . $conf_nom . '&nbsp;&nbsp;=&nbsp;&nbsp;' . $conf_valeur . '</b><br>';
-                    } elseif( ($conf_type=="texte") || ($conf_type=="path") ) {
+                    } elseif ( ($conf_type=="texte") || ($conf_type=="path") ) {
                         $childTable .= '<b>' . $conf_nom . '</b>&nbsp;=&nbsp;<input type="text" class="form-control" size="50" maxlength="200" name="tab_new_values[' . $conf_nom . ']" value="' . $conf_valeur . '"><br>';
                     } elseif ($conf_type=="boolean") {
                         $childTable .= '<b>' . $conf_nom . '</b>&nbsp;=&nbsp;<select class="form-control" name="tab_new_values[' . $conf_nom . ']">';
                         $childTable .= '<option value="TRUE"';
-                        if($conf_valeur=="TRUE") {
+                        if ($conf_valeur=="TRUE") {
                             $childTable .= ' selected';
                         }
                         $childTable .= '>TRUE</option>';
                         $childTable .= '<option value="FALSE"';
-                        if($conf_valeur=="FALSE") {
+                        if ($conf_valeur=="FALSE") {
                             $childTable .= ' selected';
                         }
                         $childTable .= '>FALSE</option>';
                         $childTable .= '</select><br>';
-                    } elseif(substr($conf_type,0,4)=="enum") {
+                    } elseif (substr($conf_type,0,4)=="enum") {
                         $childTable .= '<b>' . $conf_nom . '</b>&nbsp;=&nbsp;<select class="form-control" name="tab_new_values[' . $conf_nom . ']">';
                         $options=explode("/", substr(strstr($conf_type, '='),1));
-                        for($i=0; $i<count($options); $i++) {
+                        for ($i=0; $i<count($options); $i++) {
                             $childTable .= '<option value="' . $options[$i] . '"';
-                            if($conf_valeur==$options[$i]) {
+                            if ($conf_valeur==$options[$i]) {
                                 $childTable .= ' selected';
                             }
                             $childTable .= '>' . $options[$i] . '</option>';
@@ -779,13 +778,12 @@ class Fonctions
 
         /*** initialisation des variables ***/
         $action="";
-        $tab_new_values=array();
+        $tab_new_values= [];
         /************************************/
 
         /*************************************/
         // recup des parametres reçus :
         // SERVER
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         // GET / POST
         $action         = getpost_variable('action') ;
         $tab_new_values = getpost_variable('tab_new_values');

--- a/config/config_type_absence.php
+++ b/config/config_type_absence.php
@@ -44,16 +44,19 @@ switch ($action) {
             'absences' => _('divers_absences_maj_1'),
             'conges_exceptionnels' => _('divers_conges_exceptionnels_maj_1'),
         ];
+        $classesConges = array_keys($titres);
         $comments = [
             'conges' => _('config_abs_comment_conges'),
             'absences' => _('config_abs_comment_absences'),
             'conges_exceptionnels' => _('config_abs_comment_conges_exceptionnels'),
         ];
-
         $traductions = [
             'titres' => $titres,
             'commentaires' => $comments,
         ];
+        if (!$isCongesExceptionnelsActive && isset($classesConges['conges_exceptionnels'])) {
+            unset($classesConges['conges_exceptionnels']);
+        }
         $url = $PHP_SELF;
 
         $nouveauLibelle = $tab_new_values['libelle'] ?? '';

--- a/config/config_type_absence.php
+++ b/config/config_type_absence.php
@@ -54,8 +54,9 @@ switch ($action) {
             'titres' => $titres,
             'commentaires' => $comments,
         ];
-        if (!$isCongesExceptionnelsActive && isset($classesConges['conges_exceptionnels'])) {
-            unset($classesConges['conges_exceptionnels']);
+        $offsetCongesExceptionnels = array_search('conges_exceptionnels', $classesConges);
+        if (!$isCongesExceptionnelsActive && is_int($offsetCongesExceptionnels)) {
+            unset($classesConges[$offsetCongesExceptionnels]);
         }
         $url = $PHP_SELF;
 
@@ -65,5 +66,3 @@ switch ($action) {
         require_once VIEW_PATH .  'Configuration/Type_Absence/Liste.php';
         break;
 }
-
-bottom();

--- a/config/index.php
+++ b/config/index.php
@@ -61,3 +61,4 @@ $_SESSION['from_config']=true;  // initialise ce flag pour changer le bouton de 
 		}
 
 	echo '</div>';
+    bottom();

--- a/responsable/resp_cloture_exercice.php
+++ b/responsable/resp_cloture_exercice.php
@@ -2,4 +2,3 @@
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
 echo \responsable\Fonctions::clotureExerciceModule();
-bottom();


### PR DESCRIPTION
Fix #546 

Il n'était pas possible d'ajouter / modifier des types d'absences avec accent. C'est corrigé.

J'ai profité que j'étais là pour : 
* corriger un bug graphique sur l'affichage des congés exceptionnels dans les types d'absences
* corriger les défauts simples remontés par codacy