### PR TITLE
authentification CAS

### DIFF
--- a/App/Patchs/Maj/1.13.3.sql
+++ b/App/Patchs/Maj/1.13.3.sql
@@ -1,1 +1,2 @@
  DELETE FROM `conges_config` WHERE conf_nom = 'double_validation_conges';
+ UPDATE `conges_config` SET conf_type='enum=dbconges/ldap/cas/sso' WHERE conf_nom = 'how_to_connect_user';

--- a/App/Tools/libraries
+++ b/App/Tools/libraries
@@ -27,6 +27,9 @@ if (is_file(CONFIG_PATH . 'dbconnect.php')) {
 if (is_file(CONFIG_PATH . 'config_ldap.php')) {
     require_once CONFIG_PATH . 'config_ldap.php';
 }
+if (is_file(CONFIG_PATH . 'config_CAS.php')) {
+    require_once CONFIG_PATH . 'config_CAS.php';
+}
 
 function displayFail()
 {

--- a/App/Tools/update
+++ b/App/Tools/update
@@ -43,7 +43,7 @@ function setInstalledVersion(\includes\SQL $db, $versionCode) : bool
  *
  * @param array $data Données de configuration
  */
-function setDataConfigurationApi(array $dbConfiguration, array $ldapConfiguration) : bool
+function setDataConfigurationApi(array $dbConfiguration, array $ldapConfiguration, array $casConfiguration) : bool
 {
     $data = [
         'db' => [
@@ -67,6 +67,12 @@ function setDataConfigurationApi(array $dbConfiguration, array $ldapConfiguratio
             'nom_affiche' => $ldapConfiguration['nom_affiche'],
             'filtre' => $ldapConfiguration['filtre'],
             'filtre_recherche' => $ldapConfiguration['filtre_recherche'],
+        ],
+        'cas' => [
+            'serveur' => $casConfiguration['serveur'],
+            'port' => $casConfiguration['port'],
+            'uri' => $casConfiguration['uri'],
+            'caCert' => $casConfiguration['caCert'],
         ],
     ];
 
@@ -104,7 +110,13 @@ $ldapConfiguration = [
     'filtre' => $config_ldap_filtre ?? '',
     'filtre_recherche' => $config_ldap_filrech ?? '',
 ];
-if (!setDataConfigurationApi($dbConfiguration, $ldapConfiguration)) {
+$casConfiguration = [
+    'serveur' => $config_CAS_host ?? '',
+    'port' => $config_CAS_portNumber ?? '',
+    'uri' => $config_CAS_URI ?? '',
+    'caCert' => $config_CAS_CACERT ?? ''
+];
+if (!setDataConfigurationApi($dbConfiguration, $ldapConfiguration, $casConfiguration)) {
     displayFail();
 }
 

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -271,6 +271,8 @@ function authentification_passwd_conges_CAS()
     $config_CAS_portNumber =$_SESSION['config']['CAS_portNumber'];
     $config_CAS_URI        =$_SESSION['config']['CAS_URI'];
     $config_CAS_CACERT     =$_SESSION['config']['CAS_CACERT'];
+    $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
+
 
     global $connexionCAS;
     global $logoutCas;
@@ -300,7 +302,7 @@ function authentification_passwd_conges_CAS()
     \phpCAS::forceAuthentication();
 
     $usernameCAS = \phpCAS::getUser();
-    $userPT = \phpCAS::retrievePT("https://api", $err_code, $err_msg);
+    $userPT = \phpCAS::retrievePT( $config->getUrlAccueil() . "/api/", $err_code, $err_msg);
 
     $array = ['username' => $usernameCAS, 'proxyTicket' => $userPT];
 

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -280,9 +280,9 @@ function authentification_passwd_conges_CAS()
 
     // initialisation phpCAS
     if ($connexionCAS!="active") {
-        $CASCnx = \phpCAS::client(CAS_VERSION_2_0, $config_CAS_host, $config_CAS_portNumber, $config_CAS_URI);
+        \phpCAS::proxy(CAS_VERSION_2_0, $config_CAS_host, $config_CAS_portNumber, $config_CAS_URI);
+        \phpCAS::setPGTStorageFile("/tmp");
         $connexionCAS = "active";
-
     }
 
     if ($logoutCas==1) {
@@ -300,6 +300,13 @@ function authentification_passwd_conges_CAS()
     \phpCAS::forceAuthentication();
 
     $usernameCAS = \phpCAS::getUser();
+    $userPT = \phpCAS::retrievePT("https://api", $err_code, $err_msg);
+
+    $array = ['username' => $usernameCAS, 'proxyTicket' => $userPT];
+
+    return $array;
+
+
 
     //On nettoie la session créée par phpCAS
     session_destroy();

--- a/index.php
+++ b/index.php
@@ -125,7 +125,7 @@ if (!session_is_valid()) {
         case 'cas':
             authCas($api, $config);
             break;
-        case 'SSO':
+        case 'sso':
             authSso($api);
             break;
         default:

--- a/index.php
+++ b/index.php
@@ -53,12 +53,12 @@ function errorAuthentification() {
 function authCas(\App\Libraries\ApiClient $api, \App\Libraries\Configuration $config)
 {
     try {
-        $usernameCAS = authentification_passwd_conges_CAS();
-        if ($usernameCAS == "") {
+        $authData = authentification_passwd_conges_CAS();
+        if ($authData['username'] == "") {
             throw new \Exception("Nom d'utilisateur vide");
         }
-        session_create($usernameCAS);
-        storeTokenApi($api, $usernameCAS, '');
+        session_create($authData['username']);
+        storeTokenApi($api, $authData['username'], $authData['proxyTicket']);
     } catch (\Exception $e) {
         errorAuthentification();
         deconnexion_CAS($config->getUrlAccueil());


### PR DESCRIPTION
Ça commence à prendre forme! désormais, lors de l'authentification par CAS, lt-web sollicite un proxy ticket auprès du serveur CAS puis le transmet, en guise de mot de passe, à l'API (PR en préparation coté api).

il manque tout de même un détail, @prytoegrian tu sauras peut être me répondre, j'ai besoin de transmettre l'adresse de l'API au serveur CAS dans le fichier includes/fonction.php:303. Quel est la "bonne" manière de l'obtenir.

EDIT : Il me suffit d'utiliser l'url stoqué dans conges_config :man_facepalming: 