### PR TITLE
Ignorer les congés annulés dans l'export ICS

### DIFF
--- a/export/Fonctions.php
+++ b/export/Fonctions.php
@@ -126,6 +126,8 @@ class Fonctions
     					case "refus":
     						$status="CANCELLED";
     						break;
+    					case "annul":
+    						continue 2;
     					default:
     						$status="TENTATIVE";
     					}

--- a/export/Fonctions.php
+++ b/export/Fonctions.php
@@ -126,10 +126,8 @@ class Fonctions
     					case "refus":
     						$status="CANCELLED";
     						break;
-    					case "annul":
-    						continue 2;
     					default:
-    						$status="TENTATIVE";
+    						continue 2;
     					}
     				if($sql_demi_jour_deb=="am")
     					$DTSTART=$tab_date_deb[0].$tab_date_deb[1].$tab_date_deb[2]."T070000Z";   // .....


### PR DESCRIPTION
Cf https://github.com/libertempo/web/issues/696#issuecomment-497591774, testé sur la v1.11. Plus d'entrées 'TENTATIVE' pour les congés annulés par un RH.