### PR TITLE
un responsable peut ajouter un conges

### DIFF
--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -830,7 +830,7 @@ function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $moi
     // si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
     // OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
     // OU si le user est un RH ou un admin
-	if (( $config->canUserSaisieDemande() && $user_login==$_SESSION['userlogin'] ) || ( $config->canResponsableSaisieMission() && is_resp($_SESSION['userlogin']) ) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']))	
+if (( $config->canUserSaisieDemande() && $user_login==$_SESSION['userlogin'] ) || ( $config->canResponsableSaisieMission() && is_resp($_SESSION['userlogin']) ) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']))	
 	{
         // congés
         $return .= '<div class="col-md-4">';

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -830,7 +830,7 @@ function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $moi
     // si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
     // OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
     // OU si le user est un RH ou un admin
-    if (( $config->canUserSaisieDemande() && $user_login==$_SESSION['userlogin'] ) || ( $config->canResponsableSaisieMission() && is_resp($_SESSION['userlogin']) ) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']))	
+    if (( $config->canUserSaisieDemande() && $user_login==$_SESSION['userlogin'] ) || ( $config->canResponsableSaisieMission() && \App\ProtoControllers\Responsable::isRespDeUtilisateur($_SESSION['userlogin'] , $user_login)) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']))	
     {
         // congés
         $return .= '<div class="col-md-4">';

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -830,7 +830,7 @@ function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $moi
     // si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
     // OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
     // OU si le user est un RH ou un admin
-if (( $config->canUserSaisieDemande() && $user_login==$_SESSION['userlogin'] ) || ( $config->canResponsableSaisieMission() && is_resp($_SESSION['userlogin']) ) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']))	
+    if (( $config->canUserSaisieDemande() && $user_login==$_SESSION['userlogin'] ) || ( $config->canResponsableSaisieMission() && is_resp($_SESSION['userlogin']) ) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']))	
 	{
         // congés
         $return .= '<div class="col-md-4">';

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -830,8 +830,8 @@ function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $moi
     // si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
     // OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
     // OU si le user est un RH ou un admin
-	
-    if (( $config->canUserSaisieDemande() && $user_login==$_SESSION['userlogin'] ) || ( $config->canresponsableSaisieMission() && is_resp($_SESSION['userlogin']) ) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin'])) {
+	if (( $config->canUserSaisieDemande() && $user_login==$_SESSION['userlogin'] ) || ( $config->canResponsableSaisieMission() && is_resp($_SESSION['userlogin']) ) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']))	
+	{
         // congés
         $return .= '<div class="col-md-4">';
         $return .= '<label>' . _('divers_conges') . '</label>';

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -830,8 +830,7 @@ function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $moi
     // si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
     // OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
     // OU si le user est un RH ou un admin
-    if (( $config->canUserSaisieDemande() && $user_login==$_SESSION['userlogin'] ) || ( $config->canResponsableSaisieMission() && \App\ProtoControllers\Responsable::isRespDeUtilisateur($_SESSION['userlogin'] , $user_login)) || is_hr($_SESSION['userlogin']))	
-    {
+    if (( $config->canUserSaisieDemande() && $user_login==$_SESSION['userlogin'] ) || ( $config->canResponsableSaisieMission() && \App\ProtoControllers\Responsable::isRespDeUtilisateur($_SESSION['userlogin'] , $user_login)) || is_hr($_SESSION['userlogin'])) {
         // congés
         $return .= '<div class="col-md-4">';
         $return .= '<label>' . _('divers_conges') . '</label>';

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -831,7 +831,7 @@ function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $moi
     // OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
     // OU si le user est un RH ou un admin
     if (( $config->canUserSaisieDemande() && $user_login==$_SESSION['userlogin'] ) || ( $config->canResponsableSaisieMission() && is_resp($_SESSION['userlogin']) ) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']))	
-	{
+    {
         // congés
         $return .= '<div class="col-md-4">';
         $return .= '<label>' . _('divers_conges') . '</label>';

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -830,7 +830,8 @@ function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $moi
     // si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
     // OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
     // OU si le user est un RH ou un admin
-    if (( $config->canUserSaisieDemande() && $user_login==$_SESSION['userlogin'] ) || ( !$config->canUserSaisieDemande() && $user_login!=$_SESSION['userlogin'] ) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin'])) {
+	
+    if (( $config->canUserSaisieDemande() && $user_login==$_SESSION['userlogin'] ) || ( $config->canresponsableSaisieMission() && is_resp($_SESSION['userlogin']) ) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin'])) {
         // congés
         $return .= '<div class="col-md-4">';
         $return .= '<label>' . _('divers_conges') . '</label>';

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -830,7 +830,7 @@ function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $moi
     // si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
     // OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
     // OU si le user est un RH ou un admin
-    if (( $config->canUserSaisieDemande() && $user_login==$_SESSION['userlogin'] ) || ( $config->canResponsableSaisieMission() && \App\ProtoControllers\Responsable::isRespDeUtilisateur($_SESSION['userlogin'] , $user_login)) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']))	
+    if (( $config->canUserSaisieDemande() && $user_login==$_SESSION['userlogin'] ) || ( $config->canResponsableSaisieMission() && \App\ProtoControllers\Responsable::isRespDeUtilisateur($_SESSION['userlogin'] , $user_login)) || is_hr($_SESSION['userlogin']))	
     {
         // congés
         $return .= '<div class="col-md-4">';


### PR DESCRIPTION
Un responsable de groupe pouvait saisir des motifs d'absence mais pas de congés.
Seul les HR et comptes admin pouvaient le faire.
A présent un responsable de groupe peut ajouter un congés
Au préalable dans la configuration resp_saisie_mission = TRUE 