### PR TITLE
[métier] saisie des heures additionnelles dans le passé

### DIFF
--- a/App/ProtoControllers/Employe/Heure/Additionnelle.php
+++ b/App/ProtoControllers/Employe/Heure/Additionnelle.php
@@ -59,7 +59,7 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
         $datesFeries        = \utilisateur\Fonctions::getDatePickerJoursFeries();
         $datesFerme         = \utilisateur\Fonctions::getDatePickerFermeture();
         $datesDisabled      = array_merge($datesFeries, $datesFerme);
-        $startDate          = \utilisateur\Fonctions::getDatePickerStartDate();
+        $startDate          = '';
 
         $datePickerOpts = [
             'daysOfWeekDisabled' => $daysOfWeekDisabled,


### PR DESCRIPTION
Les heures additionnelles se posent généralement après consommation, contrairement aux congés et heures de repos. 

Pour tester : 
c'est très simple, il suffit d'interdire les demandes de congés dans le passé puis de déposer une demande d'heure additionnelle.