### PR TITLE
[1.13] mise à jour composer.lock

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -734,12 +734,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/libertempo/api.git",
-                "reference": "495bee70b616777499afcc0704e9bec816a30170"
+                "reference": "0157d7259069b12b9c0c3c0dfef5bc472f420366"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libertempo/api/zipball/495bee70b616777499afcc0704e9bec816a30170",
-                "reference": "495bee70b616777499afcc0704e9bec816a30170",
+                "url": "https://api.github.com/repos/libertempo/api/zipball/0157d7259069b12b9c0c3c0dfef5bc472f420366",
+                "reference": "0157d7259069b12b9c0c3c0dfef5bc472f420366",
                 "shasum": ""
             },
             "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.11.0",
+  "version": "1.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,7 +10,7 @@
       "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
       "requires": {
         "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
+        "is-buffer": "2.0.4"
       }
     },
     "bootstrap": {
@@ -23,7 +23,7 @@
       "resolved": "https://registry.npmjs.org/bootstrap-datepicker/-/bootstrap-datepicker-1.9.0.tgz",
       "integrity": "sha512-9rYYbaVOheGYxjOr/+bJCmRPihfy+LkLSg4fIFMT9Od8WwWB/MB50w0JO1eBgKUMbb7PFHQD5uAfI3ArAxZRXA==",
       "requires": {
-        "jquery": ">=1.7.1 <4.0.0"
+        "jquery": "3.4.0"
       }
     },
     "bootstrap-timepicker": {
@@ -44,7 +44,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
-        "debug": "=3.1.0"
+        "debug": "3.1.0"
       }
     },
     "font-awesome": {
@@ -53,9 +53,9 @@
       "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
     },
     "is-buffer": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "jquery": {
       "version": "3.4.0",


### PR DESCRIPTION
Je me suis un peu planté sur l'upgrade d'une lib composer, il ne suffit pas de modifier le fichier à la main... 
bizarrement j'avais systématiquement la bonne version sur mon poste... Un effet du cache de composer peut être. 

P.S. : Bernard et TxR s'occupe du test. @prytoegrian, si tu as un peu de temps, jette un coup d’œil au code stp 