### PR TITLE
patch bug affichage employé par le grand responsable

### DIFF
--- a/App/ProtoControllers/Responsable.php
+++ b/App/ProtoControllers/Responsable.php
@@ -136,6 +136,20 @@ class Responsable
     }
 
     /**
+     * Vérifie si un utilisateur est bien le grand responsable d'un employé
+     *
+     * @param string $resp
+     * @param string $user
+     *
+     * @return bool
+     */
+    public static function isGrandRespDeUtilisateur($resp, $user)
+    {
+        return $resp != $user
+                && \App\ProtoControllers\Groupe::isGrandResponsableGroupe($resp, \App\ProtoControllers\Utilisateur::getGroupesId($user), \includes\SQL::singleton());
+    }
+
+    /**
      * Vérifie si un utilisateur est responsable par délégation d'un employé
      *
      * @param string $resp

--- a/responsable/Fonctions.php
+++ b/responsable/Fonctions.php
@@ -888,7 +888,8 @@ class Fonctions
         };
         $userLogin = $entities(getpost_variable('user_login'));
 
-        if (!\App\ProtoControllers\Responsable::isRespDeUtilisateur($_SESSION['userlogin'], $userLogin)) {
+        if (!(\App\ProtoControllers\Responsable::isRespDeUtilisateur($_SESSION['userlogin'], $userLogin)
+                || \App\ProtoControllers\Responsable::isGrandRespDeUtilisateur($_SESSION['userlogin'])))  {
             redirect(ROOT_PATH . 'deconnexion');
             exit;
         }


### PR DESCRIPTION
lorsqu'un grand responsable souhaite accéder au traitement individuel d'un employé (l'oeil dans la page principale), il est déconnecté. Ce PR corrige ce bug.

pour tester, se connecter en tant que grand responsable puis cliquer sur l’œil en bout de ligne d'un employé depuis la page principale du responsable. L'employé ne doit pas être sous la responsabilité direct du grand responsable.

[ticket feedback](https://feedback.libertempo.fr/home/idea/41).