### PR TITLE
Clé primaire partout

### DIFF
--- a/App/Patchs/Maj/1.14.1.sql
+++ b/App/Patchs/Maj/1.14.1.sql
@@ -17,7 +17,7 @@ ALTER TABLE conges_config ADD INDEX conf_nom (conf_nom);
 #
 ALTER TABLE conges_echange_rtt MODIFY e_login varbinary(99) NOT NULL DEFAULT '';
 ALTER TABLE conges_echange_rtt DROP PRIMARY KEY;
-ALTER TABLE conges_echange_rtt ADD echange_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT FIRST;
+ALTER TABLE conges_echange_rtt ADD e_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT FIRST;
 ALTER TABLE conges_echange_rtt ADD INDEX login_date (e_login, e_date_jour);
 #
 # Add an int PK on conges_jours_feries
@@ -33,18 +33,6 @@ ALTER TABLE conges_periode MODIFY p_num int(5) unsigned NOT NULL;
 ALTER TABLE conges_periode DROP PRIMARY KEY;
 ALTER TABLE conges_periode ADD p_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT FIRST;
 ALTER TABLE conges_periode ADD INDEX p_num (p_num);
-#
-# Add an int PK on conges_groupe_grd_resp
-#
-ALTER TABLE conges_groupe_grd_resp MODIFY ggr_gid int(11) NOT NULL PRIMARY KEY AUTO_INCREMENT;
-#
-# Add an int PK on conges_groupe_resp
-#
-ALTER TABLE conges_groupe_resp MODIFY gr_gid int(11) NOT NULL PRIMARY KEY AUTO_INCREMENT;
-#
-# Add an int PK on conges_groupe_users
-#
-ALTER TABLE conges_groupe_users MODIFY gu_gid int(11) NOT NULL PRIMARY KEY AUTO_INCREMENT;
 #
 # Add an int PK on conges_jours_fermeture
 #

--- a/App/Patchs/Maj/1.14.1.sql
+++ b/App/Patchs/Maj/1.14.1.sql
@@ -36,11 +36,13 @@ ALTER TABLE conges_periode ADD INDEX p_num (p_num);
 #
 # Add an int PK on conges_jours_fermeture
 #
-ALTER TABLE conges_jours_fermeture MODIFY jf_id int(5) NOT NULL PRIMARY KEY AUTO_INCREMENT;
+ALTER TABLE conges_jours_fermeture ADD id INT NOT NULL PRIMARY KEY AUTO_INCREMENT FIRST;
+
 #
 # Add an int PK on conges_solde_edition
 #
-ALTER TABLE conges_solde_edition MODIFY se_id_edition int(11) NOT NULL PRIMARY KEY AUTO_INCREMENT;
+ALTER TABLE conges_solde_edition ADD id INT NOT NULL PRIMARY KEY AUTO_INCREMENT FIRST;
+
 #
 # Add an int PK on conges_mail
 #

--- a/App/Patchs/Maj/1.14.1.sql
+++ b/App/Patchs/Maj/1.14.1.sql
@@ -1,0 +1,73 @@
+#
+# Add an int PK on config_appli
+#
+ALTER TABLE conges_appli MODIFY appli_variable varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '';
+ALTER TABLE conges_appli DROP PRIMARY KEY;
+ALTER TABLE conges_appli ADD appli_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT FIRST;
+ALTER TABLE conges_appli ADD INDEX appli_variable (appli_variable);
+#
+# Add an int PK on config_appli
+#
+ALTER TABLE conges_config MODIFY conf_nom varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '';
+ALTER TABLE conges_config DROP PRIMARY KEY;
+ALTER TABLE conges_config ADD config_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT FIRST;
+ALTER TABLE conges_config ADD INDEX conf_nom (conf_nom);
+#
+# Add an int PK on conges_echange_rtt
+#
+ALTER TABLE conges_echange_rtt MODIFY e_login varbinary(99) NOT NULL DEFAULT '';
+ALTER TABLE conges_echange_rtt DROP PRIMARY KEY;
+ALTER TABLE conges_echange_rtt ADD echange_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT FIRST;
+ALTER TABLE conges_echange_rtt ADD INDEX login_date (e_login, e_date_jour);
+#
+# Add an int PK on conges_jours_feries
+#
+ALTER TABLE conges_jours_feries MODIFY jf_date date NOT NULL DEFAULT '0000-00-00';
+ALTER TABLE conges_jours_feries DROP PRIMARY KEY;
+ALTER TABLE conges_jours_feries ADD jf_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT FIRST;
+ALTER TABLE conges_jours_feries ADD INDEX jf_date (jf_date);
+#
+# Add an int PK on conges_periode
+#
+ALTER TABLE conges_periode MODIFY p_num int(5) unsigned NOT NULL;
+ALTER TABLE conges_periode DROP PRIMARY KEY;
+ALTER TABLE conges_periode ADD p_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT FIRST;
+ALTER TABLE conges_periode ADD INDEX p_num (p_num);
+#
+# Add an int PK on conges_groupe_grd_resp
+#
+ALTER TABLE conges_groupe_grd_resp MODIFY ggr_gid int(11) NOT NULL PRIMARY KEY AUTO_INCREMENT;
+#
+# Add an int PK on conges_groupe_resp
+#
+ALTER TABLE conges_groupe_resp MODIFY gr_gid int(11) NOT NULL PRIMARY KEY AUTO_INCREMENT;
+#
+# Add an int PK on conges_groupe_users
+#
+ALTER TABLE conges_groupe_users MODIFY gu_gid int(11) NOT NULL PRIMARY KEY AUTO_INCREMENT;
+#
+# Add an int PK on conges_jours_fermeture
+#
+ALTER TABLE conges_jours_fermeture MODIFY jf_id int(5) NOT NULL PRIMARY KEY AUTO_INCREMENT;
+#
+# Add an int PK on conges_solde_edition
+#
+ALTER TABLE conges_solde_edition MODIFY se_id_edition int(11) NOT NULL PRIMARY KEY AUTO_INCREMENT;
+#
+# Add an int PK on conges_mail
+#
+ALTER TABLE conges_mail ADD mail_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT FIRST;
+#
+# Add an int PK on conges_solde_user
+#
+ALTER TABLE conges_solde_user MODIFY su_login varbinary(99) NOT NULL DEFAULT '';
+ALTER TABLE conges_solde_user DROP PRIMARY KEY;
+ALTER TABLE conges_solde_user ADD su_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT FIRST;
+ALTER TABLE conges_solde_user ADD INDEX login_abs (su_login, su_abs_id);
+#
+# Add an int PK on conges_users
+#
+ALTER TABLE conges_users MODIFY u_login varbinary(99) NOT NULL DEFAULT '';
+ALTER TABLE conges_users DROP PRIMARY KEY;
+ALTER TABLE conges_users ADD u_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT FIRST;
+ALTER TABLE conges_users ADD INDEX u_login (u_login);

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -386,8 +386,8 @@ class Fonctions
                     while ($resultat1 = $ReqLog_users->fetch_array()) {
                         $current_login=$resultat1["u_login"];
 
-                        $req_insert2="INSERT INTO conges_solde_user (su_login, su_abs_id, su_nb_an, su_solde, su_reliquat) " .
-                            "VALUES ('$current_login', $new_abs_id, 0, 0, 0) ";
+                        $req_insert2="INSERT INTO conges_solde_user (su_id, su_login, su_abs_id, su_nb_an, su_solde, su_reliquat) " .
+                            "VALUES (DEFAULT, '$current_login', $new_abs_id, 0, 0, 0) ";
                         \includes\SQL::query($req_insert2);
                     }
                 }

--- a/edition/Fonctions.php
+++ b/edition/Fonctions.php
@@ -1175,6 +1175,9 @@ class Fonctions
         // recup du tableau des types de conges (seulement les conges)
         $tab_type_cong=recup_tableau_types_conges();
         foreach ($tab_type_cong as $id_abs => $libelle) {
+            if (!isset($tab_solde_user[$id_abs])) {
+                continue;
+            }
             $sql_insert_2 = "INSERT INTO conges_solde_edition
                     SET se_id_edition=$new_edition_id, se_id_absence=$id_abs, se_solde=$tab_solde_user[$id_abs] ";
             $result_insert_2 = \includes\SQL::query($sql_insert_2);
@@ -1182,6 +1185,9 @@ class Fonctions
         if ($config->isCongesExceptionnelsActive()) {
             $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
             foreach ($tab_type_conges_exceptionnels as $id_abs => $libelle) {
+                if (!isset($tab_solde_user[$id_abs])) {
+                    continue;
+                }
                 $sql_insert_3 = "INSERT INTO conges_solde_edition SET se_id_edition=$new_edition_id, se_id_absence=$id_abs, se_solde=$tab_solde_user[$id_abs] ";
                 $result_insert_3 = \includes\SQL::query($sql_insert_3);
             }

--- a/hr/hr_ajout_user.php
+++ b/hr/hr_ajout_user.php
@@ -194,24 +194,24 @@ function insertSoldeUtilisateur(array $data, \includes\SQL $sql) : bool
     $typeAbsencesConges = \App\ProtoControllers\Conge::getTypesAbsences($sql, 'conges');
 
     foreach ($typeAbsencesConges as $typeId => $info) {
-        $valuesStd[] = "('" . $data['login'] . "' ,"
+        $valuesStd[] = "(DEFAULT, '" . $data['login'] . "' ,"
                             . $typeId . ", "
                             . $data['joursAn'][$typeId] . ", "
                             . $data['soldes'][$typeId] . ", "
                             . $data['reliquats'][$typeId] . ")" ;
     }
-    $req = "INSERT INTO conges_solde_user (su_login, su_abs_id, su_nb_an, su_solde, su_reliquat) VALUES " . implode(",", $valuesStd);
+    $req = "INSERT INTO conges_solde_user (su_id, su_login, su_abs_id, su_nb_an, su_solde, su_reliquat) VALUES " . implode(",", $valuesStd);
     $returnStd = $sql->query($req);
     $returnExc = 1;
     if ($config->isCongesExceptionnelsActive()) {
         $typeAbsencesExceptionnels = \App\ProtoControllers\Conge::getTypesAbsences($sql, 'conges_exceptionnels');
         foreach ($typeAbsencesExceptionnels as $typeId => $info) {
-            $valuesExc[] = "('" . $data['login'] . "' ,"
+            $valuesExc[] = "(DEFAULT, '" . $data['login'] . "' ,"
                                 . $typeId . ", 0, "
                                 . $data['soldes'][$typeId] . ", 0)" ;
 
         }
-        $req = "INSERT INTO conges_solde_user (su_login, su_abs_id, su_nb_an, su_solde, su_reliquat) VALUES " . implode(",", $valuesExc);
+        $req = "INSERT INTO conges_solde_user (su_id, su_login, su_abs_id, su_nb_an, su_solde, su_reliquat) VALUES " . implode(",", $valuesExc);
         $returnExc = $sql->query($req);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,9 +53,9 @@
       "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
     },
     "is-buffer": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "jquery": {
       "version": "3.4.1",

--- a/utilisateur/Fonctions.php
+++ b/utilisateur/Fonctions.php
@@ -1001,8 +1001,8 @@ class Fonctions
             }
             else // sinon : on insert
             {
-                $sql1 = "INSERT into conges_echange_rtt (e_login, e_date_jour, e_absence, e_presence, e_comment)
-                    VALUES ('".$_SESSION['userlogin']."','$new_debut','$nouvelle_absence_date_1', '$nouvelle_presence_date_1', '$new_comment')" ;
+                $sql1 = "INSERT into conges_echange_rtt (e_id, e_login, e_date_jour, e_absence, e_presence, e_comment)
+                    VALUES (DEFAULT, '".$_SESSION['userlogin']."','$new_debut','$nouvelle_absence_date_1', '$nouvelle_presence_date_1', '$new_comment')" ;
             }
             $result1 = \includes\SQL::query($sql1);
 
@@ -1022,8 +1022,8 @@ class Fonctions
             }
             else // sinon: on insert
             {
-                $sql2 = "INSERT into conges_echange_rtt (e_login, e_date_jour, e_absence, e_presence, e_comment)
-                    VALUES ('".$_SESSION['userlogin']."','$new_fin','$nouvelle_absence_date_2', '$nouvelle_presence_date_2', '$new_comment')" ;
+                $sql2 = "INSERT into conges_echange_rtt (e_id, e_login, e_date_jour, e_absence, e_presence, e_comment)
+                    VALUES (DEFAULT, '".$_SESSION['userlogin']."','$new_fin','$nouvelle_absence_date_2', '$nouvelle_presence_date_2', '$new_comment')" ;
             }
             $result2 = \includes\SQL::query($sql2);
 


### PR DESCRIPTION
Fix https://github.com/libertempo/api/issues/21

Désormais, toutes les tables ont une clé primaire bien formée. Lorsque je devais muter l'index, j'en ai recréé un pour être sûr de ne pas perdre en performance.

Évidemment, il faut passer sur tous les endroits impliquant ces tables pour être certain d'avoir des requêtes bien formées partout. Il faut aussi faire des insertion, puisque les indexes sont très sensibles à ça.

Ce correctif est un prérequis à https://github.com/libertempo/api/issues/100.