### PR TITLE
patch table solde unique par utilisateur

### DIFF
--- a/App/Patchs/Maj/1.14.2.sql
+++ b/App/Patchs/Maj/1.14.2.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `conges_solde_user` ADD UNIQUE( `su_login`, `su_abs_id`);


### PR DESCRIPTION
petit patch suite à un bug né de #858. Fix #859 

pour tester c'est très simple,en tant qu'HR modifier le solde d'un utilisateur puis vérifier dans la table conges_solde_user qu'il n'existe qu'un seul type d'absence (su_abs_id) par utilisateur (su_login).