### PR TITLE
Adaptation au nouveau docker

### DIFF
--- a/App/Views/Configuration/Type_Absence/Liste.php
+++ b/App/Views/Configuration/Type_Absence/Liste.php
@@ -136,6 +136,6 @@ var optionsVue = {
             console.error(error);
         })
     }
-});
+};
 </script>
 <?php

--- a/Tests/script_jeutest.php
+++ b/Tests/script_jeutest.php
@@ -4,7 +4,7 @@ define('INCLUDE_PATH',     ROOT_PATH . 'includes/');
 require_once INCLUDE_PATH . 'define.php';
 
 // SERVER
-$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+$PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
 
 // récupération des valeurs par défaut
 if (!empty($_POST)) {

--- a/calcul_nb_jours_pris.php
+++ b/calcul_nb_jours_pris.php
@@ -13,7 +13,7 @@ $p_num="";
 /*************************************/
 // recup des parametres reçus :
 // SERVER
-$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+$PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
 // GET  / POST
 $user       = getpost_variable('user') ;
 $date_debut = getpost_variable('date_debut') ;

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -23,7 +23,7 @@ class Fonctions
 
     private static function confirmer_vider_table_logs()
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $return = '';
 
         $return .= '<center>';
@@ -40,7 +40,7 @@ class Fonctions
 
     public static function affichage($login_par)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $return = '';
 
         //requête qui récupère les logs
@@ -129,7 +129,7 @@ class Fonctions
         /*************************************/
         // recup des parametres reçus :
         // SERVER
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         // GET / POST
         $action         = htmlentities(getpost_variable('action', ""), ENT_QUOTES | ENT_HTML401);
         $login_par      = htmlentities(getpost_variable('login_par', ""), ENT_QUOTES | ENT_HTML401);
@@ -150,7 +150,7 @@ class Fonctions
 
     private static function commit_modif($tab_new_values)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $return = '';
 
         $URL = "$PHP_SELF";
@@ -174,7 +174,7 @@ class Fonctions
 
     public static function test_config()
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $return = '';
 
         $URL = "$PHP_SELF";
@@ -197,7 +197,7 @@ class Fonctions
 
     public static function affichage_config_mail()
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $return = '';
 
         $URL = "$PHP_SELF";
@@ -287,7 +287,7 @@ class Fonctions
         /*************************************/
         // recup des parametres reçus :
         // SERVER
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         // GET / POST
         $action = getpost_variable('action');
         $tab_new_values = getpost_variable('tab_new_values');
@@ -320,7 +320,7 @@ class Fonctions
 
     public static function commit_ajout(&$tab_new_values)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $return = '';
 
         $URL = $PHP_SELF;
@@ -403,7 +403,7 @@ class Fonctions
 
     public static function commit_suppr($id_to_update)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $return = '';
 
         $URL = $PHP_SELF;
@@ -427,7 +427,7 @@ class Fonctions
 
     public static function supprimer($id_to_update)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $return = '';
 
         $URL = parse_url($PHP_SELF, PHP_URL_PATH);
@@ -491,7 +491,7 @@ class Fonctions
 
     public static function commit_modif_absence(&$tab_new_values, $id_to_update)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $return = '';
 
         $URL = $PHP_SELF;
@@ -565,7 +565,7 @@ class Fonctions
 
     public static function modifier(&$tab_new_values, $id_to_update)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $return = '';
 
         $URL = parse_url($PHP_SELF, PHP_URL_PATH);
@@ -619,7 +619,7 @@ class Fonctions
 
     private static function commit_saisie(&$tab_new_values)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $return = '';
 
         $URL = "$PHP_SELF";
@@ -679,7 +679,7 @@ class Fonctions
 
     private static function affichage_configuration()
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $return = '';
 
         // affichage de la liste des variables

--- a/config/config_type_absence.php
+++ b/config/config_type_absence.php
@@ -13,7 +13,7 @@ require_once INCLUDE_PATH . 'session.php';
 // verif des droits du user à afficher la page
 verif_droits_user("is_admin");
 
-$PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+$PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
 $action         = getpost_variable('action');
 $tab_new_values = getpost_variable('tab_new_values');
 $id_to_update   = htmlentities(getpost_variable('id_to_update'), ENT_QUOTES | ENT_HTML401);

--- a/config/index.php
+++ b/config/index.php
@@ -14,7 +14,7 @@ $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
 $_SESSION['config']=init_config_tab();      // on initialise le tableau des variables de config
 require_once INCLUDE_PATH .'session.php';
 
-$PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+$PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
 
 // verif des droits du user à afficher la page
 verif_droits_user("is_admin");

--- a/edition/Fonctions.php
+++ b/edition/Fonctions.php
@@ -235,7 +235,7 @@ class Fonctions
         /*************************************/
         // recup des parametres reçus :
         // SERVER
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         // GET / POST
         $user_login = htmlentities(getpost_variable('user_login', $_SESSION['userlogin']), ENT_QUOTES | ENT_HTML401);
         $return = '';

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -12,7 +12,7 @@ class Fonctions
 
         $db = \includes\SQL::singleton();
         $config = new \App\Libraries\Configuration($db);
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $return = '';
 
         while($elem_tableau = each($tab_bt_radio)) {
@@ -78,7 +78,7 @@ class Fonctions
         $return = '';
         $db = \includes\SQL::singleton();
         $config = new \App\Libraries\Configuration($db);
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $count1=0;
         $count2=0;
 
@@ -259,7 +259,7 @@ class Fonctions
 
     public static function new_conges($user_login, $numero_int, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type_id) : string
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         $new_debut = convert_date($new_debut);
@@ -312,7 +312,7 @@ class Fonctions
     {
         $db = \includes\SQL::singleton();
         $config = new \App\Libraries\Configuration($db);
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         // recup dans un tableau de tableau les infos des types de conges et absences
@@ -398,7 +398,7 @@ class Fonctions
     {
         $db = \includes\SQL::singleton();
         $config = new \App\Libraries\Configuration($db);
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         // recup dans un tableau de tableau les infos des types de conges et absences
@@ -449,7 +449,7 @@ class Fonctions
     {
         $db = \includes\SQL::singleton();
         $config = new \App\Libraries\Configuration($db);
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         // affichage de l'année et des boutons de défilement
@@ -598,7 +598,7 @@ class Fonctions
     {
         $db = \includes\SQL::singleton();
         $config = new \App\Libraries\Configuration($db);
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         // Récupération des informations
@@ -700,7 +700,7 @@ class Fonctions
     {
         $db = \includes\SQL::singleton();
         $config = new \App\Libraries\Configuration($db);
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         // Récupération des informations
@@ -1012,7 +1012,7 @@ class Fonctions
 
     public static function affichage_saisie_globale_groupe($tab_type_conges) : string
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         /***********************************************************************/
@@ -1311,7 +1311,7 @@ class Fonctions
         \hr\Fonctions::get_tableau_jour_fermeture($year, $tab_year,  $groupe_id);
         // navigation
         $onglet = htmlentities(getpost_variable('onglet'), ENT_QUOTES | ENT_HTML401);
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $return = '<div class="btn-group pull-right">';
         $prev_link = "$PHP_SELF?year=". ($year - 1) . "&groupe_id=$groupe_id";
         $return .= '<a href="' . $prev_link . '" class="btn btn-default"><i class="fa fa-chevron-left"></i></a>';
@@ -1393,7 +1393,7 @@ class Fonctions
 
     private static function commit_annul_fermeture($fermeture_id, $groupe_id) : string
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $db = \includes\SQL::singleton();
         $return = '';
 
@@ -1467,7 +1467,7 @@ class Fonctions
 
     private static function commit_new_fermeture($new_date_debut, $new_date_fin, $groupe_id, $id_type_conges) : string
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $return = '';
 
         // on transforme les formats des dates
@@ -1555,7 +1555,7 @@ class Fonctions
 
     private static function confirm_annul_fermeture($fermeture_id, $groupe_id, $fermeture_date_debut, $fermeture_date_fin) : string
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
         $return = '';
 
         $return .= '<div class="wrapper">';
@@ -1938,7 +1938,7 @@ class Fonctions
         //Initialisation de variables
         $unJour = 3600*24;
         $tbJourFerie = [];
-        $timePaques = easter_date($iAnnee) + 6 * 3600; // évite les changements d'heures
+        $timePaques = \easter_date($iAnnee) + 6 * 3600; // évite les changements d'heures
 
         $tbJourFerie["Jour de l an"] = $iAnnee . "-01-01";
         $tbJourFerie["Paques"] = date('Y-m-d', $timePaques);

--- a/hr/hr_ajout_conges.php
+++ b/hr/hr_ajout_conges.php
@@ -205,7 +205,7 @@ if ('true' === $ajout_groupe) {
 }
 
 $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
-$PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+$PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
 
 // recup du tableau des types de conges (seulement les congesexceptionnels )
 if ($config->isCongesExceptionnelsActive()) {

--- a/hr/hr_index.php
+++ b/hr/hr_index.php
@@ -15,7 +15,7 @@ verif_droits_user("is_hr");
 /*************************************/
 // recup des parametres reçus :
 // SERVER
-$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+$PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
 // GET / POST
 $onglet = getpost_variable('onglet', "page_principale");
 

--- a/hr/hr_jours_chomes.php
+++ b/hr/hr_jours_chomes.php
@@ -77,7 +77,7 @@ function afficheJourMois($mois, $i, $year, $tab_year) : string
 // verif des droits du user à afficher la page
 verif_droits_user("is_hr");
 
-$PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+$PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
 // GET / POST
 $PHP_SELF = parse_url($PHP_SELF, PHP_URL_PATH);
 $choix_action = getpost_variable('choix_action');

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -190,7 +190,7 @@ function session_delete()
 //
 function session_saisie_user_password($erreur, $session_username)
 {
-    $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+    $PHP_SELF = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
     header_login('');
     include_once TEMPLATE_PATH . 'login_form.php';
 
@@ -763,7 +763,7 @@ function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $moi
 {
     $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
 
-    $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+    $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
     $new_date_fin = date('d/m/Y');
     $return = '';
 

--- a/responsable/Fonctions.php
+++ b/responsable/Fonctions.php
@@ -19,7 +19,7 @@ class Fonctions
         // $tab_new_nb_conges_all[$id_conges]= nb_jours
         // $tab_calcul_proportionnel[$id_conges]= TRUE / FALSE
 
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $db = \includes\SQL::singleton();
         $return = '';
 
@@ -78,7 +78,7 @@ class Fonctions
 
     public static function ajout_global($tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $db = \includes\SQL::singleton();
         $return = '';
 
@@ -139,7 +139,7 @@ class Fonctions
 
     public static function ajout_conges($tab_champ_saisie, $tab_commentaire_saisie)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         foreach ($tab_champ_saisie as $user_name => $tab_conges)   // tab_champ_saisie[$current_login][$id_conges]=valeur du nb de jours ajouté saisi
@@ -174,7 +174,7 @@ class Fonctions
 
     private static function new_conges($user_login, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type_id)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         //conversion des dates
@@ -227,7 +227,7 @@ class Fonctions
     {
         $db = \includes\SQL::singleton();
         $config = new \App\Libraries\Configuration($db);
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         // recup dans un tableau de tableau les infos des types de conges et absences
@@ -312,7 +312,7 @@ class Fonctions
     {
         $db = \includes\SQL::singleton();
         $config = new \App\Libraries\Configuration($db);
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         // recup dans un tableau de tableau les infos des types de conges et absences
@@ -362,7 +362,7 @@ class Fonctions
     {
         $db = \includes\SQL::singleton();
         $config = new \App\Libraries\Configuration($db);
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         // affichage de l'année et des boutons de défilement
@@ -510,7 +510,7 @@ class Fonctions
     {
         $db = \includes\SQL::singleton();
         $config = new \App\Libraries\Configuration($db);
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         // Récupération des informations
@@ -615,7 +615,7 @@ class Fonctions
     {
         $db = \includes\SQL::singleton();
         $config = new \App\Libraries\Configuration($db);
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         // Récupération des informations
@@ -732,7 +732,7 @@ class Fonctions
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
 
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         // on initialise le tableau global des jours fériés s'il ne l'est pas déjà :
@@ -1041,7 +1041,7 @@ class Fonctions
         $yearPrec = $year - 1;
         $yearSucc = $year + 1;
         $db = \includes\SQL::singleton();
-        $url = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $url = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         $return .= '<div class="calendar-nav">';
@@ -1213,7 +1213,7 @@ class Fonctions
         $yearPrec = $year - 1;
         $yearSucc = $year + 1;
         $db = \includes\SQL::singleton();
-        $url = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $url = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         $return .= '<div class="calendar-nav">';

--- a/responsable/resp_index.php
+++ b/responsable/resp_index.php
@@ -15,7 +15,7 @@ verif_droits_user("is_resp");
 /*************************************/
 // recup des parametres reçus :
 // SERVER
-$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+$PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
 // GET / POST
 $onglet = getpost_variable('onglet', "page_principale");
 

--- a/utilisateur/Fonctions.php
+++ b/utilisateur/Fonctions.php
@@ -57,7 +57,7 @@ class Fonctions
         $new_fin = convert_date($new_fin);
         $return = '';
 
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
 
         // verif validité des valeurs saisies
         $valid = verif_saisie_new_demande($new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $_SESSION['userlogin']);
@@ -239,7 +239,7 @@ class Fonctions
     private static function modifier($p_num_to_update, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $p_etat, $onglet)
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
         $VerifNb = verif_saisie_decimal($new_nb_jours);
 
@@ -273,7 +273,7 @@ class Fonctions
     private static function confirmer($p_num, $onglet)
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         // Récupération des informations
@@ -474,7 +474,7 @@ class Fonctions
     private static function suppression($p_num_to_delete, $onglet)
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         if ($config->isSendMailSupprimeDemandeResponsable()) {
@@ -503,7 +503,7 @@ class Fonctions
 
     private static function confirmerSuppression($p_num, $onglet)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $return = '';
 
         // Récupération des informations
@@ -775,7 +775,7 @@ class Fonctions
     {
         $return = '';
 
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
 
         $duree_demande_1="";
         $duree_demande_2="";
@@ -1052,7 +1052,7 @@ class Fonctions
     private static function saisie_echange_rtt($user_login, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $onglet)
     {
         $return = '';
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
         $mois_calendrier_saisie_debut_prec=0; $year_calendrier_saisie_debut_prec=0;
         $mois_calendrier_saisie_debut_suiv=0; $year_calendrier_saisie_debut_suiv=0;
         $mois_calendrier_saisie_fin_prec=0; $year_calendrier_saisie_fin_prec=0;

--- a/utilisateur/user_changer_mot_de_passe.php
+++ b/utilisateur/user_changer_mot_de_passe.php
@@ -2,7 +2,7 @@
 defined('_PHP_CONGES') or die('Restricted access');
 
 $titre = _('user_change_password');
-$self = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+$self = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
 
 if (getpost_variable('change_passwd', 0) == 1) {
     $new_passwd1 = getpost_variable('new_passwd1');

--- a/utilisateur/user_index.php
+++ b/utilisateur/user_index.php
@@ -7,7 +7,7 @@ require_once INCLUDE_PATH . 'session.php';
 $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
 
 // SERVER
-$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+$PHP_SELF = filter_var($_SERVER['PHP_SELF'], FILTER_SANITIZE_URL);
 // GET / POST
 $onglet = getpost_variable('onglet');
 


### PR DESCRIPTION
Le docker https://github.com/libertempo/docker/pull/37 requiert quelques adaptations vis à vis de FPM. En effet, un bug officiel et non encore corrigé à ce jour retourne null pour les filter_input (https://bugs.php.net/bug.php?id=49184), j'ai donc dû passer par des filter_var. Ça revient au même.

Cette PR n'a pas besoin du merge de la PR de docker, elle peut être mergée quand on veut.