### PR TITLE
type d'absence optionnel

### DIFF
--- a/App/Libraries/Configuration.php
+++ b/App/Libraries/Configuration.php
@@ -359,11 +359,6 @@ class Configuration
         return $this->getGroupeFonctionnementEtablissementValeur('grand_resp_ajout_conges');
     }
 
-    public function isCongesExceptionnelsActive()
-    {
-        return $this->getGroupeFonctionnementEtablissementValeur('gestion_conges_exceptionnels');
-    }
-
     public function canSoldeNegatif()
     {
         return !$this->getGroupeFonctionnementEtablissementValeur('solde_toujours_positif');

--- a/App/Patchs/Maj/1.14.2.sql
+++ b/App/Patchs/Maj/1.14.2.sql
@@ -1,0 +1,4 @@
+# Création champ option type absence
+ALTER TABLE `conges_type_absence` ADD `ta_actif` TINYINT(1) NOT NULL DEFAULT '1';
+# Retrait option globale congés exceptionnels
+DELETE FROM `conges_config` WHERE `conf_nom` = 'gestion_conges_exceptionnels';

--- a/App/ProtoControllers/Conge.php
+++ b/App/ProtoControllers/Conge.php
@@ -306,9 +306,10 @@ class Conge
     {
         $typesConges = [];
         $req = 'SELECT ta_id, ta_libelle, ta_type
-                FROM conges_type_absence';
+                FROM conges_type_absence
+                WHERE ta_actif = 1';
         if (null != $type) {
-            $req .= ' WHERE ta_type=\'' . $type . '\'';
+            $req .= ' AND ta_type=\'' . $type . '\'';
         }
         $data   = $sql->query($req);
 

--- a/App/ProtoControllers/HautResponsable/ClotureExercice.php
+++ b/App/ProtoControllers/HautResponsable/ClotureExercice.php
@@ -43,7 +43,7 @@ class ClotureExercice
     private static function updateSoldesEmploye($employe, $typeConges, $comment, \includes\SQL $sql, \App\Libraries\Configuration $config)
     {
         $return = true;
-        $soldesEmploye = \App\ProtoControllers\Utilisateur::getSoldesEmploye($sql, $config, $employe);
+        $soldesEmploye = \App\ProtoControllers\Utilisateur::getSoldesEmploye($sql, $employe);
         if (!empty($soldesEmploye)) {
             foreach ($typeConges as $idType => $libelle) {
                 $soldeRestant = $soldesEmploye[$idType]['su_solde'];

--- a/App/ProtoControllers/Utilisateur.php
+++ b/App/ProtoControllers/Utilisateur.php
@@ -248,17 +248,15 @@ class Utilisateur
      *
      * @return array
      */
-    public static function getSoldesEmploye(\includes\SQL $sql, \App\Libraries\Configuration $config, $login)
+    public static function getSoldesEmploye(\includes\SQL $sql, $login)
     {
         $soldes = [];
         $req = 'SELECT ta_id, ta_libelle, su_nb_an, su_solde, su_reliquat
                 FROM conges_solde_user, conges_type_absence
                 WHERE conges_type_absence.ta_id = conges_solde_user.su_abs_id
-                AND su_login = "' . $login . '" ';
-        if (!$config->isCongesExceptionnelsActive()) {
-            $req .= 'AND conges_type_absence.ta_type != \'conges_exceptionnels\'';
-        }
-        $req .= 'ORDER BY su_abs_id ASC;';
+                AND su_login = "' . $login . '"
+                AND conges_type_absence.ta_actif = 1
+                ORDER BY su_abs_id ASC;';
         $res = $sql->query($req);
 
         while ($infos = $res->fetch_assoc()) {

--- a/App/Views/Configuration/Type_Absence/Liste.php
+++ b/App/Views/Configuration/Type_Absence/Liste.php
@@ -79,7 +79,6 @@ var optionsVue = {
         nouveauLibelleCourt : '<?= $nouveauLibelleCourt ?>',
         nouveauType : '<?= $nouveauType ?>',
         traductions : <?= json_encode($traductions) ?>,
-        isCongesExceptionnelsActive: 'true',
         axios : instance,
         classesConges : <?= json_encode($classesConges) ?>
     },
@@ -121,9 +120,6 @@ var optionsVue = {
                     organisedTypes[absenceType.type] = new Array();
                 }
                 organisedTypes[absenceType.type].push(absenceType);
-            }
-            if (!vm.isCongesExceptionnelsActive && undefined != organisedTypes['conges_exceptionnels']) {
-                delete organisedTypes['conges_exceptionnels'];
             }
 
             // Finally hide loader and show var

--- a/App/Views/Configuration/Type_Absence/Liste.php
+++ b/App/Views/Configuration/Type_Absence/Liste.php
@@ -5,7 +5,6 @@
  * $nouveauType
  * $traductions
  * $url
- * $isCongesExceptionnelsActive
  * $classesConges
  */
 ?>
@@ -80,7 +79,7 @@ var optionsVue = {
         nouveauLibelleCourt : '<?= $nouveauLibelleCourt ?>',
         nouveauType : '<?= $nouveauType ?>',
         traductions : <?= json_encode($traductions) ?>,
-        isCongesExceptionnelsActive: 'true' == "<?= $isCongesExceptionnelsActive ? 'true' : 'false' ?>",
+        isCongesExceptionnelsActive: 'true',
         axios : instance,
         classesConges : <?= json_encode($classesConges) ?>
     },
@@ -136,6 +135,6 @@ var optionsVue = {
             console.error(error);
         })
     }
-});
+};
 </script>
 <?php

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "jasig/phpcas": "1.3.8",
         "yohang/calendr": "^2.0",
         "guzzlehttp/guzzle": "6.3.3",
-        "libertempo/api": "1.9.0",
+        "libertempo/api": "1.10.0",
         "rollbar/rollbar": "1.8.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -741,7 +741,7 @@
         },
         {
             "name": "libertempo/api",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libertempo/api.git",
@@ -757,8 +757,9 @@
                 "adldap2/adldap2": "10.0.6",
                 "doctrine/dbal": "2.9.2",
                 "php": "^7.1",
-                "php-di/php-di": "6.0.8",
+                "php-di/php-di": "6.0.11",
                 "rollbar/rollbar": "1.8.1",
+                "doctrine/orm": "2.6.6",
                 "slim/slim": "3.12.1"
             },
             "require-dev": {

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -425,6 +425,26 @@ class Fonctions
         return $return;
     }
 
+    public static function commit_desac($id)
+    {
+        $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
+        $return = '';
+
+        $URL = $PHP_SELF;
+
+        // delete dans la table conges_type_absence
+        $req='UPDATE FROM conges_type_absence set ta_actif = 0 WHERE ta_id='. \includes\SQL::quote($id);
+        \includes\SQL::query($req);
+
+        $return .= '<span class="messages">' . _('form_modif_ok') . '</span><br>';
+
+        $comment_log = "config : desactivation type absence ($id) ";
+        log_action(0, "", "", $comment_log);
+        $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $URL . '">';
+
+        return $return;
+    }
+
     public static function supprimer($id_to_update)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
@@ -461,8 +481,15 @@ class Fonctions
 
             $return .= '<br>';
             $return .= '<form action="' . $URL . '" method="POST">';
-            $return .= '<input type="submit" value="' . _('form_redo') . '" >';
+            $return .= '<input type="submit" value="' . _('form_annul') . '" >';
             $return .= '</form>';
+            if ($absenceType['typeActif']) {
+                $return .= '<form action="' . $URL . '" method="POST">';
+                $return .= '<input type="hidden" name="action" value="commit_desac">';
+                $return .= '<input type="hidden" name="id_to_update" value="' . $id_to_update . '">';
+                $return .= '<input type="submit" value="' . _('form_desactive') . '" >';
+                $return .= '</form>';
+            }
             $return .= '<br><br>';
             $return .= '</center>';
         } else {

--- a/config/config_type_absence.php
+++ b/config/config_type_absence.php
@@ -34,6 +34,9 @@ switch ($action) {
     case 'commit_suppr':
         echo \config\Fonctions::commit_suppr($id_to_update);
         break;
+    case 'commit_desac':
+        echo \config\Fonctions::commit_desac($id_to_update);
+        break;
     default:
         $sql = \includes\SQL::singleton();
         $config = new \App\Libraries\Configuration($sql);

--- a/config/config_type_absence.php
+++ b/config/config_type_absence.php
@@ -37,7 +37,6 @@ switch ($action) {
     default:
         $sql = \includes\SQL::singleton();
         $config = new \App\Libraries\Configuration($sql);
-        $isCongesExceptionnelsActive = $config->isCongesExceptionnelsActive();
         $titres = [
             'conges' => _('divers_conges_maj_1'),
             'absences' => _('divers_absences_maj_1'),
@@ -54,7 +53,7 @@ switch ($action) {
             'commentaires' => $comments,
         ];
         $offsetCongesExceptionnels = array_search('conges_exceptionnels', $classesConges);
-        if (!$isCongesExceptionnelsActive && is_int($offsetCongesExceptionnels)) {
+        if (is_int($offsetCongesExceptionnels)) {
             unset($classesConges[$offsetCongesExceptionnels]);
         }
         $url = $PHP_SELF;

--- a/edition/Fonctions.php
+++ b/edition/Fonctions.php
@@ -297,11 +297,7 @@ class Fonctions
         // recup du tableau des types de conges exceptionnels (seulement les conge sexceptionnels )
         $tab_type_cong=recup_tableau_types_conges();
         // recup du tableau des types de conges (seulement les conges)
-        if ($config->isCongesExceptionnelsActive()) {
-            $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
-        } else {
-            $tab_type_conges_exceptionnels=array();
-        }
+        $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
         // recup du tableau de tous les types de conges
         $tab_type_all_cong=recup_tableau_tout_types_abs();
 
@@ -835,11 +831,7 @@ class Fonctions
         // recup du tableau des types de conges (seulement les conges)
         $tab_type_cong=recup_tableau_types_conges();
         // recup du tableau des types de conges exceptionnels (seulement les conges exceptionnels)
-        if ($config->isCongesExceptionnelsActive()) {
-            $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
-        } else {
-            $tab_type_conges_exceptionnels = [];
-        }
+        $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
         // recup du tableau de tous les types de conges
         $tab_type_all_cong=recup_tableau_tout_types_abs();
 
@@ -1182,7 +1174,6 @@ class Fonctions
                     SET se_id_edition=$new_edition_id, se_id_absence=$id_abs, se_solde=$tab_solde_user[$id_abs] ";
             $result_insert_2 = \includes\SQL::query($sql_insert_2);
         }
-        if ($config->isCongesExceptionnelsActive()) {
             $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
             foreach ($tab_type_conges_exceptionnels as $id_abs => $libelle) {
                 if (!isset($tab_solde_user[$id_abs])) {
@@ -1191,7 +1182,6 @@ class Fonctions
                 $sql_insert_3 = "INSERT INTO conges_solde_edition SET se_id_edition=$new_edition_id, se_id_absence=$id_abs, se_solde=$tab_solde_user[$id_abs] ";
                 $result_insert_3 = \includes\SQL::query($sql_insert_3);
             }
-        }
 
         /********************************************************************************************/
         /* Update du num edition dans la table periode pour les Conges et demandes de cette edition */

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -82,10 +82,7 @@ class Fonctions
         $count1=0;
         $count2=0;
 
-        $typeAbsence = \App\ProtoControllers\Conge::getTypesAbsences($db, 'conges');
-        if ($config->isCongesExceptionnelsActive()) {
-            $typeAbsence += \App\ProtoControllers\Conge::getTypesAbsences($db, 'conges_exceptionnels');
-        }
+        $typeAbsence = \App\ProtoControllers\Conge::getTypesAbsences($db);
 
         /*********************************/
         // Récupération des informations

--- a/hr/hr_ajout_conges.php
+++ b/hr/hr_ajout_conges.php
@@ -208,11 +208,7 @@ $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
 $PHP_SELF = filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL);
 
 // recup du tableau des types de conges (seulement les congesexceptionnels )
-if ($config->isCongesExceptionnelsActive()) {
-    $tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
-} else {
-    $tab_type_conges_exceptionnels = [];
-}
+$tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
 
 // recup de la liste de TOUS les users pour le RH
 // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)

--- a/hr/hr_ajout_user.php
+++ b/hr/hr_ajout_user.php
@@ -50,9 +50,8 @@ if ($config->isUsersExportFromLdap()) {
     $optLdap = 'onkeyup="searchLdapUser()" autocomplete="off"';
 }
 
-if ($config->isCongesExceptionnelsActive()) {
-    $typeAbsencesExceptionnels = \App\ProtoControllers\Conge::getTypesAbsences($sql, 'conges_exceptionnels');
-}
+$typeAbsencesExceptionnels = \App\ProtoControllers\Conge::getTypesAbsences($sql, 'conges_exceptionnels');
+
 /**
  * Nettoyage des données postés par le formulaire
  *
@@ -203,17 +202,15 @@ function insertSoldeUtilisateur(array $data, \includes\SQL $sql) : bool
     $req = "INSERT INTO conges_solde_user (su_id, su_login, su_abs_id, su_nb_an, su_solde, su_reliquat) VALUES " . implode(",", $valuesStd);
     $returnStd = $sql->query($req);
     $returnExc = 1;
-    if ($config->isCongesExceptionnelsActive()) {
-        $typeAbsencesExceptionnels = \App\ProtoControllers\Conge::getTypesAbsences($sql, 'conges_exceptionnels');
-        foreach ($typeAbsencesExceptionnels as $typeId => $info) {
-            $valuesExc[] = "(DEFAULT, '" . $data['login'] . "' ,"
-                                . $typeId . ", 0, "
-                                . $data['soldes'][$typeId] . ", 0)" ;
+    $typeAbsencesExceptionnels = \App\ProtoControllers\Conge::getTypesAbsences($sql, 'conges_exceptionnels');
+    foreach ($typeAbsencesExceptionnels as $typeId => $info) {
+        $valuesExc[] = "(DEFAULT, '" . $data['login'] . "' ,"
+                            . $typeId . ", 0, "
+                            . $data['soldes'][$typeId] . ", 0)" ;
 
-        }
-        $req = "INSERT INTO conges_solde_user (su_id, su_login, su_abs_id, su_nb_an, su_solde, su_reliquat) VALUES " . implode(",", $valuesExc);
-        $returnExc = $sql->query($req);
     }
+    $req = "INSERT INTO conges_solde_user (su_id, su_login, su_abs_id, su_nb_an, su_solde, su_reliquat) VALUES " . implode(",", $valuesExc);
+    $returnExc = $sql->query($req);
 
     return $returnStd && $returnExc;
 }

--- a/hr/hr_page_principale.php
+++ b/hr/hr_page_principale.php
@@ -31,11 +31,7 @@ $return = '';
 $titre = _('admin_onglet_gestion_user');
 
 $typeAbsencesConges = \App\ProtoControllers\Conge::getTypesAbsences($sql, 'conges');
-$typeAbsencesExceptionnels = [];
-
-if ($config->isCongesExceptionnelsActive()) {
-    $typeAbsencesExceptionnels = \App\ProtoControllers\Conge::getTypesAbsences($sql, 'conges_exceptionnels');
-}
+$typeAbsencesExceptionnels = \App\ProtoControllers\Conge::getTypesAbsences($sql, 'conges_exceptionnels');
 
 $infoUsers = \App\ProtoControllers\Utilisateur::getDonneesTousUtilisateurs($config);
 asort($infoUsers);
@@ -57,7 +53,7 @@ foreach ($infoUsers as $login => $infosUser) {
 
     $infoUsers[$login]['rights'] = $rights;
     $infoUsers[$login]['responsables'] = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($login);
-    $infoUsers[$login]['soldes'] = \App\ProtoControllers\Utilisateur::getSoldesEmploye($sql, $config, $login);
+    $infoUsers[$login]['soldes'] = \App\ProtoControllers\Utilisateur::getSoldesEmploye($sql, $login);
 }
 
 /**

--- a/responsable/resp_index.php
+++ b/responsable/resp_index.php
@@ -82,10 +82,7 @@ header_menu('', 'Libertempo : ' . _('divers_responsable_maj_1'));
 $tab_type_cong = recup_tableau_types_conges();
 
 // recup du tableau des types de conges exceptionnels (seulement les conges exceptionnels)
-$tab_type_conges_exceptionnels = array();
-if ($config->isCongesExceptionnelsActive()) {
-    $tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
-}
+$tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
 
 echo '<div class="' . $onglet . ' wrapper" id="main-content">';
 require_once ROOT_PATH . 'responsable/resp_' . $onglet . '.php';

--- a/responsable/resp_page_principale.php
+++ b/responsable/resp_page_principale.php
@@ -3,9 +3,6 @@ defined('_PHP_CONGES') or die('Restricted access');
 
 $typeConges = $tab_type_cong;
 $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
-$congesExceptionnels = ($config->isCongesExceptionnelsActive())
-    ? $tab_type_conges_exceptionnels
-    : [];
 
 $gestionHeure = $config->isHeuresAutorise();
 $gestionEditionPapier = $config->canEditPapier();
@@ -15,7 +12,7 @@ $subalternesActifsResponsable = array_filter(
         return 'Y' == $employe['is_active'];
     }
 );
-$nombreColonnes = 3 + 2 * count($typeConges) + count($congesExceptionnels) + (int) $gestionHeure + 1 + (int) $gestionEditionPapier;
+$nombreColonnes = 3 + 2 * count($typeConges) + count($tab_type_conges_exceptionnels) + (int) $gestionHeure + 1 + (int) $gestionEditionPapier;
 
 $subalternesGrandResponsable = recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
 $subalternesActifsGrandResponsable = array_filter(

--- a/utilisateur/Fonctions.php
+++ b/utilisateur/Fonctions.php
@@ -1417,7 +1417,8 @@ class Fonctions
         $options = [];
         $sql = \includes\SQL::singleton();
         $req = 'SELECT ta_libelle, ta_short_libelle
-                FROM conges_type_absence';
+                FROM conges_type_absence
+                WHERE ta_actif = 1';
         $res = $sql->query($req);
 
         while ($data = $res->fetch_array()) {


### PR DESCRIPTION
Afin d'offrir plus de granularité dans la gestion des types d'absences, j'ai retiré l'option globale "gestion_conges_exceptionnels" au profit de la possibilité de désactiver un type d'absence. 
Lorsqu'un type d'absence est désactivé, il n'est plus possible de déposer une demande de congés sur ce type, mais l'historique de l'employé reste intact. 

Cette fonctionnalité à besoin de [api#134](https://github.com/libertempo/api/pull/134).