### PR TITLE
Update Ldap.php to avoid warnings

### DIFF
--- a/App/Libraries/Ldap.php
+++ b/App/Libraries/Ldap.php
@@ -70,7 +70,7 @@ class Ldap
 
     public function getEmailUser($login)
     {
-        $filter = "(&(" . $this->configuration['attrLogin'] . "=" . $login . ")(" . 
+        $filter = "(&(" . $this->configuration['attrLogin'] . "=" . $login . ")(" .
                     $this->configuration['attrFiltre'] . "=" . $this->configuration['filtre'] . "))";
 
         $attributs = [$this->configuration['attrLogin'], $this->configuration['attrMail']];

--- a/App/Libraries/Ldap.php
+++ b/App/Libraries/Ldap.php
@@ -70,8 +70,8 @@ class Ldap
 
     public function getEmailUser($login)
     {
-        $filter = "(&(" . $this->configuration['attrLogin'] . "=" . $login . ")
-                    (" . $this->configuration['attrFiltre'] . "=" . $this->configuration['filtre'] . "))";
+        $filter = "(&(" . $this->configuration['attrLogin'] . "=" . $login . ")(" . 
+                    $this->configuration['attrFiltre'] . "=" . $this->configuration['filtre'] . "))";
 
         $attributs = [$this->configuration['attrLogin'], $this->configuration['attrMail']];
 


### PR DESCRIPTION
Change some characters in the filter's concatenation string (lines 73  and 74) in order to get rid of a lot of warning on the web interface when displaying all the users on the index page, HR side.